### PR TITLE
URO-82, URO-168 Add share narrative function.

### DIFF
--- a/src/common/api/workspaceApi.ts
+++ b/src/common/api/workspaceApi.ts
@@ -56,6 +56,12 @@ interface wsParams {
     showDeleted?: boolean;
     showOnlyDeleted?: boolean;
   } & TimeParams;
+  setwsGlobalPermissions: { permission: PermissionValue; wsId: number };
+  setwsUsersPermissions: {
+    permission: PermissionValue;
+    users: string[];
+    wsId: number;
+  };
 }
 
 interface wsResults {
@@ -95,6 +101,8 @@ interface wsResults {
     size: number,
     meta: Record<string, string>
   ][][];
+  setwsGlobalPermissions: unknown;
+  setwsUsersPermissions: unknown;
 }
 
 const wsApi = baseApi.injectEndpoints({
@@ -159,6 +167,26 @@ const wsApi = baseApi.injectEndpoints({
           params: [params],
         }),
     }),
+    setwsGlobalPermissions: builder.mutation<
+      wsResults['setwsGlobalPermissions'],
+      wsParams['setwsGlobalPermissions']
+    >({
+      query: ({ permission, wsId }) =>
+        ws({
+          method: 'Workspace.set_global_permission',
+          params: [{ id: wsId, new_permission: permission }],
+        }),
+    }),
+    setwsUsersPermissions: builder.mutation<
+      wsResults['setwsUsersPermissions'],
+      wsParams['setwsUsersPermissions']
+    >({
+      query: ({ permission, users, wsId }) =>
+        ws({
+          method: 'Workspace.set_permissions',
+          params: [{ users, id: wsId, new_permission: permission }],
+        }),
+    }),
   }),
 });
 
@@ -169,4 +197,6 @@ export const {
   getwsPermissions,
   listObjects,
   listWorkspaceInfo,
+  setwsGlobalPermissions,
+  setwsUsersPermissions,
 } = wsApi.endpoints;

--- a/src/features/navigator/common.ts
+++ b/src/features/navigator/common.ts
@@ -115,12 +115,3 @@ export const normalizeVersion = (verRaw?: number | string) => {
   }
   return verNumber.toString();
 };
-
-export const TODOAddLoadingState = () =>
-  new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve(
-        console.log('TODO: Add a loading state for this.') // eslint-disable-line no-console
-      );
-    }, 1000);
-  });

--- a/src/features/navigator/navigatorSlice.ts
+++ b/src/features/navigator/navigatorSlice.ts
@@ -109,7 +109,12 @@ export const navigatorSlice = createSlice({
         shares: filtered,
         sharesCount: Object.keys(filtered).length,
       };
-      const newState = { ...state, controlMenu };
+      const newState = {
+        ...state,
+        synchronizedLast: Date.now(),
+        synchronized: false,
+        controlMenu,
+      };
       const message = `Remove ${username} permissions for ${wsId}.`;
       console.log(message); // eslint-disable-line no-console
       return newState;
@@ -198,6 +203,8 @@ export const navigatorSlice = createSlice({
     ) => {
       const { permission, username, wsId } = action.payload;
       state.controlMenu.shares[username] = permission;
+      state.synchronizedLast = Date.now();
+      state.synchronized = false;
       const message = `Set ${username} permission on ${wsId} to ${permission}.`;
       console.log(message); // eslint-disable-line no-console
       return state;


### PR DESCRIPTION
This PR adds the API calls for updating sharing in the narrative control menu. This is also the final piece of functionality for the Navigator as a whole. That is, no major new functionality remains for Navigator itself. In particular, the narrative navigator is now feature complete.

- [x] URO-82: Create Navigator Component
  - [x] Aligns roughly to mockup URO-78.
  - [x] Implement user behaviors existing in previous Navigator
  - [x] Manages state for searches and filters
  - [x] Manages quantity of search results displayed
  - [x] Manages state for the control menu including
    - [x] delete
    - [x] copy
    - [x] link (to an organization)
    - [x] rename
    - [x] restore
    - [x] share
  - [x] Handles narrative metadata changes at least to the standard of the previous Navigator
- [x] URO-168: Add API calls to the Share Narrative action in the control menu.
  - [x] Narratives can be shared (Narrative permissions of a specified level can be assigned to a specified user) using the Narrative Control Menu. Specifically narrative admins may:
    - [x] Add a new user with selected permissions
    - [x] Remove a user from shares
    - [x] Update a user's permission level
    - [x] Make a narrative globally public or private
  - [x] If the action fails then this is shown to the user using a toast notification. Have distinct messages for when:
    - [x] The app cannot confirm action success.
