### PR TITLE
add europa fallback page for legacy 404s

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -9,6 +9,7 @@ import {
 import Auth from '../features/auth/Auth';
 import Count from '../features/count/Counter';
 import Legacy, { LEGACY_BASE_ROUTE } from '../features/legacy/Legacy';
+import { Fallback } from '../features/legacy/Fallback';
 import Navigator, {
   navigatorPath,
   navigatorPathWithCategory,
@@ -31,6 +32,7 @@ const Routes: FC = () => {
   return (
     <RRRoutes>
       <Route path={`${LEGACY_BASE_ROUTE}/*`} element={<Legacy />} />
+      <Route path="/fallback/*" element={<Fallback />} />
       <Route
         path="/profile/:usernameRequested/narratives"
         element={<Authed element={<ProfileWrapper />} />}

--- a/src/features/legacy/Fallback.tsx
+++ b/src/features/legacy/Fallback.tsx
@@ -1,30 +1,37 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import PageNotFound from '../layout/PageNotFound';
 
 /**
  * 404s from the legacy site are redirected from legacy.DOMAIN/[some/path/here] to DOMAIN/fallback/[some/path/here]
+ * this component handles these fallback redirects for pages such as '/narratives'
  */
 export const Fallback = () => {
   const location = useParams();
   const navigate = useNavigate();
 
   const fallbackPath = location['*']?.toLowerCase();
+  const [notFound, setNotFound] = useState(false);
 
-  // Make sure we are in window.top (not within an iframe)
-  // do this in a useEffect to run it before the first render
   useEffect(() => {
-    if (window.top && window !== window.top) {
+    // Make sure we are in window.top (not within an iframe),
+    if (window && window.top && window !== window.top) {
+      // Not in top window, redirect top window to current location
       window.top.location = window.location;
+    } else {
+      // We are in the top window
+      // redirect appropriately based on the fallbackPath, otherwise set notFound to true
+      if (fallbackPath === 'narratives') {
+        navigate('/narratives');
+      } else {
+        setNotFound(true);
+      }
     }
-  }, []);
+  }, [fallbackPath, navigate]);
 
-  // redirect appropriately based on the fallbackPath, or render a PageNotFound
-  if (fallbackPath === 'narratives') {
-    navigate('/narratives');
-  } else {
+  // show PageNotFound if we don't have a fallback redirect
+  if (notFound) {
     return <PageNotFound />;
   }
-
   return <p>Redirecting...</p>;
 };

--- a/src/features/legacy/Fallback.tsx
+++ b/src/features/legacy/Fallback.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import PageNotFound from '../layout/PageNotFound';
+
+/**
+ * 404s from the legacy site are redirected from legacy.DOMAIN/[some/path/here] to DOMAIN/fallback/[some/path/here]
+ */
+export const Fallback = () => {
+  const location = useParams();
+  const navigate = useNavigate();
+
+  const fallbackPath = location['*']?.toLowerCase();
+
+  // Make sure we are in window.top (not within an iframe)
+  // do this in a useEffect to run it before the first render
+  useEffect(() => {
+    if (window.top && window !== window.top) {
+      window.top.location = window.location;
+    }
+  }, []);
+
+  // redirect appropriately based on the fallbackPath, or render a PageNotFound
+  if (fallbackPath === 'narratives') {
+    navigate('/narratives');
+  } else {
+    return <PageNotFound />;
+  }
+
+  return <p>Redirecting...</p>;
+};


### PR DESCRIPTION
This fixes the double-chrome (iframe nesting) issue caused by our new nginx redirect for legacy 404s