### PR TITLE
Navigator UI Tweaks

### DIFF
--- a/src/common/components/LabelValueTable.module.scss
+++ b/src/common/components/LabelValueTable.module.scss
@@ -5,14 +5,13 @@
 
 .label-value-table td {
   padding: 0;
-  white-space: nowrap;
 }
 
 .label-value-table th {
   font-weight: bold;
   text-align: left;
   vertical-align: top;
-  white-space: nowrap;
+  width: 10rem;
 }
 
 .label-value-table tr:not(:last-child) td {

--- a/src/features/navigator/NarrativeList/NarrativeList.module.scss
+++ b/src/features/navigator/NarrativeList/NarrativeList.module.scss
@@ -105,6 +105,7 @@
   align-items: center;
   display: flex;
   font-size: 2rem;
+  margin-right: 0.5rem;
   width: 100%;
 
   a {

--- a/src/features/navigator/NarrativeList/NarrativeList.module.scss
+++ b/src/features/navigator/NarrativeList/NarrativeList.module.scss
@@ -9,20 +9,21 @@
   &.heading {
     background: none;
     border: 0;
-    padding: 0;
-  }
-
-  &.active:not(.heading) {
-    background: #cdecff;
+    border-radius: 4px;
+    padding: 0 0.5rem;
   }
 
   &.inactive {
     background: transparent;
   }
 
-  &:hover:not(.active):not(.dropdown_wrapper) {
+  &:hover:not(.dropdown_wrapper) {
     background: #eee;
     transition: background 0.15s ease-in;
+  }
+
+  &.active:not(.heading) {
+    background: #cdecff;
   }
 }
 
@@ -76,8 +77,11 @@
   font-size: 1rem;
   justify-content: space-between;
   margin: 0;
-  margin-bottom: 0.5rem;
   padding: 0;
+}
+
+.narrative_item_text:not(:last-child) {
+  margin-bottom: 0.5rem;
 }
 
 .narrative_item_outer.heading .narrative_item_title {
@@ -114,17 +118,14 @@
   }
 
   .icon {
-    font-size: 2rem;
+    font-size: 1.5rem;
+    margin-left: 0.5rem;
     stroke: #fff;
     stroke-width: 15;
   }
 
   .narrative_item_details {
     display: none;
-  }
-
-  .narrative_item_icon {
-    //.narrative_item_icon
   }
 
   .narrative_item_inner {
@@ -137,10 +138,6 @@
     align-items: center;
     font-size: 1.25rem; /* too small: 1 < 1.25 < 1.5: too big */
     width: 100%;
-  }
-
-  .narrative_item_title {
-    margin-left: 0.5rem;
   }
 }
 

--- a/src/features/navigator/NarrativeList/NarrativeViewItem.tsx
+++ b/src/features/navigator/NarrativeList/NarrativeViewItem.tsx
@@ -75,18 +75,16 @@ const NarrativeViewItem: FC<NarrativeViewItemProps> = ({
         target={linkToNarrative ? '_blank' : ''}
       >
         <div className={classes.narrative_item_inner}>
-          <div className={classes.narrative_item_icon}>
-            {linkToNarrative ? (
-              <span className={classes.icon}>
-                <FAIcon icon={faArrowUpRightFromSquare} />
-              </span>
-            ) : (
-              <></>
-            )}
-          </div>
           <div className={classes.narrative_item_text}>
             <div className={classes.narrative_item_title}>
-              {narrative_title}
+              <span>{narrative_title}</span>
+              {linkToNarrative && (
+                <span
+                  className={`${classes.narrative_item_icon} ${classes.icon}`}
+                >
+                  <FAIcon icon={faArrowUpRightFromSquare} />
+                </span>
+              )}
             </div>
             <NarrativeItemDropdown
               narrativeUPA={upa}
@@ -94,9 +92,11 @@ const NarrativeViewItem: FC<NarrativeViewItemProps> = ({
               version={pathVersion}
             />
           </div>
-          <div className={classes.narrative_item_details}>
-            Updated {timeElapsed} by {creator}
-          </div>
+          {!isHeading && (
+            <div className={classes.narrative_item_details}>
+              Updated {timeElapsed} by {creator}
+            </div>
+          )}
         </div>
       </Link>
     </section>

--- a/src/features/navigator/NarrativeMetadata.tsx
+++ b/src/features/navigator/NarrativeMetadata.tsx
@@ -157,28 +157,26 @@ const NarrativeMetadata: NarrativeMetadataType = ({ cells, narrativeDoc }) => {
           />
         </div>
         <div className={classes.column}>
-          <div className={classes.column}>
-            <LabelValueTable
-              data={[
-                {
-                  label: 'Total cells',
-                  value: cells.length,
-                },
-                {
-                  label: 'App cells',
-                  value: cellTypeCounts.kbase_app,
-                },
-                {
-                  label: 'Markdown cells',
-                  value: cellTypeCounts.markdown,
-                },
-                {
-                  label: 'Code cells',
-                  value: cellTypeCounts.code_cell,
-                },
-              ]}
-            />
-          </div>
+          <LabelValueTable
+            data={[
+              {
+                label: 'Total cells',
+                value: cells.length,
+              },
+              {
+                label: 'App cells',
+                value: cellTypeCounts.kbase_app,
+              },
+              {
+                label: 'Markdown cells',
+                value: cellTypeCounts.markdown,
+              },
+              {
+                label: 'Code cells',
+                value: cellTypeCounts.code_cell,
+              },
+            ]}
+          />
         </div>
       </div>
       {usersSharedOther && usersSharedOther.length > 0 ? (

--- a/src/features/navigator/Navigator.module.scss
+++ b/src/features/navigator/Navigator.module.scss
@@ -24,6 +24,7 @@ pre {
       background-color: use-color("info-lightest");
       border-radius: 0.5rem;
       margin: 0.25rem;
+      padding: 0.5rem;
     }
 
     >.column {
@@ -35,6 +36,8 @@ pre {
   .shares {
     background-color: use-color("info-lightest");
     border-radius: 0.5rem;
+    margin: 0.25rem;
+    padding: 0.5rem;
   }
 }
 

--- a/src/features/navigator/Navigator.module.scss
+++ b/src/features/navigator/Navigator.module.scss
@@ -17,6 +17,7 @@ pre {
   .columns {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     justify-content: space-between;
     margin-bottom: 0.25rem;
 
@@ -28,6 +29,12 @@ pre {
     }
 
     >.column {
+      flex: 1;
+      /**
+       * Flex-basis acts as the minimum width for the colum.
+       * If exceeded, the items will wrap and expand to full width.
+       */
+      flex-basis: 250px;
       min-width: 12rem; /* too small: 10 < 12 < 15: too big */
       width: 25%;
     }

--- a/src/features/navigator/Navigator.module.scss
+++ b/src/features/navigator/Navigator.module.scss
@@ -141,6 +141,7 @@ ul.shared,
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    margin-bottom: 0.5rem;
   }
 
   .tabs-container {

--- a/src/features/navigator/Navigator.module.scss
+++ b/src/features/navigator/Navigator.module.scss
@@ -29,14 +29,13 @@ pre {
     }
 
     >.column {
-      flex: 1;
       /**
+       * Flex 1 expands columns to fill as much space as they can.
        * Flex-basis acts as the minimum width for the colum.
        * If exceeded, the items will wrap and expand to full width.
        */
-      flex-basis: 250px;
-      min-width: 12rem; /* too small: 10 < 12 < 15: too big */
-      width: 25%;
+      flex: 1;
+      flex-basis: 14rem;
     }
   }
 


### PR DESCRIPTION
Some smalls UI changes to the navigator UI as mentioned in my comments in the navigator feedback doc:

- Add padding to narrative metadata
  - Improves readability and aesthetic of the metadata tables
- Add space to the left of narrative actions menu
  - These two elements were right up against each other. This is just a small visual improvement.
- Fix narrative title alignment and icon position
  - This fixes a slight misalignment with the narrative title and the icons in that component
  - This also moves the new-window icon to the right of the title. It's more common to see this icon at the end of a link and it helps improve the readability of the link content.
- Fix author name overflow and add better responsiveness to metadata columns
  - This fixes an issue with some metadata columns overflowing outside of the gray box.
  - This also changes the way the metadata column widths work, opting to have them expand to fill the whole width and wrap at smaller widths. I thought this was a visual improvement.
  - This also adds a fixed width to the bolded column in LabelValueTables so that values never get too far from their label and so that tables stacked on top of each other have values all aligned.