### PR TITLE
DEVOPSs1412 :  Europa on Next

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,12 @@
       "public_url": "/"
     },
 
+    "next": {
+      "domain": "next.kbase.us",
+      "legacy": "legacy.next.kbase.us",
+      "public_url": "/"
+    },
+
     "production": {
       "domain": "narrative.kbase.us",
       "legacy": "legacy.narrative.kbase.us",

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -296,7 +296,7 @@ const Enviroment: FC = () => {
     ci: 'CI',
     'ci-europa': 'EUR',
     'narrative-dev': 'NARDEV',
-    'next': 'NEXT',
+    next: 'NEXT',
     unknown: 'ENV?',
   }[env];
   return (

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -288,6 +288,7 @@ const Enviroment: FC = () => {
     ci: faFlask,
     'ci-europa': faFlask,
     'narrative-dev': faWrench,
+    next: faWrench,
     unknown: faQuestionCircle,
   }[env];
   const txt = {

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -296,6 +296,7 @@ const Enviroment: FC = () => {
     ci: 'CI',
     'ci-europa': 'EUR',
     'narrative-dev': 'NARDEV',
+    'next': 'NEXT',
     unknown: 'ENV?',
   }[env];
   return (

--- a/src/features/layout/layoutSlice.ts
+++ b/src/features/layout/layoutSlice.ts
@@ -3,12 +3,13 @@ import { useEffect } from 'react';
 import { useAppDispatch } from '../../common/hooks';
 
 const environments = [
-  'unknown',
-  'production',
-  'ci',
   'appdev',
+  'ci',
   'ci-europa',
   'narrative-dev',
+  'next',
+  'production',
+  'unknown',
 ] as const;
 
 interface PageState {


### PR DESCRIPTION
After exhaustive troubleshooting, I found the root cause behind the `404` errors on the `next` cluster:

``The next environment wasn't defined in Europa's env configs!``

I've updated the relevant files to include, and thus build code for, a `next` env, which now shows up under `/deploy/next`.
I've gone ahead and tested this in the next cluster using image ``ghcr.io/kbase/ui:br-DEVOPS-1412-next``.