### PR TITLE
Update Collection filter panel layout

### DIFF
--- a/src/common/components/Sidebar.module.scss
+++ b/src/common/components/Sidebar.module.scss
@@ -5,9 +5,10 @@
   border-left: 1px solid use-color("silver");
   border-right: 1px solid use-color("silver");
   display: inline-block;
+  flex-shrink: 0;
   height: 100%;
   overflow-y: auto;
-  width: 250px;
+  width: 215px;
 }
 
 .sidebar .header {

--- a/src/common/components/Table.module.scss
+++ b/src/common/components/Table.module.scss
@@ -21,7 +21,6 @@ $header-height: 2em;
     flex-grow: 1;
     flex-shrink: 1;
     overflow: auto;
-    overscroll-behavior: none;
     position: relative;
     width: inherit;
   }

--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -20,6 +20,7 @@ import classes from './Table.module.scss';
 import { Button } from './Button';
 import { CheckBox } from './CheckBox';
 import { Loader } from './Loader';
+import { HeatMapRow } from '../api/collectionsApi';
 
 export const Table = <Datum,>({
   table,
@@ -93,14 +94,6 @@ export const Table = <Datum,>({
           }
         />
       </div>
-      <div
-        style={{
-          display: 'block',
-          float: 'left',
-          clear: 'both',
-          height: '1em',
-        }}
-      />
     </div>
   );
 };
@@ -345,4 +338,24 @@ export const useTableColumns = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [JSON.stringify(fieldNames), JSON.stringify(fieldsOrdered)]
   );
+};
+
+/**
+ * Get the lower bound and upper bound of a table page (i.e. the first and last row index starting from 1).
+ * For example, if you are on page 2 of a dataset with 17 rows and the table shows 10 rows per page,
+ * then the first row is 11 and the last row is 17.
+ * Note: it's unclear how to make the type of `table` more permissive. For now I'm including an extra type specifically for the HeatMap table.
+ */
+export const usePageBounds = (
+  table: TableType<unknown[]> | TableType<HeatMapRow>
+) => {
+  const firstRow =
+    table.getState().pagination.pageIndex *
+      table.getState().pagination.pageSize +
+    1;
+  const lastRow = firstRow - 1 + table.getPaginationRowModel().rows.length;
+  return {
+    firstRow,
+    lastRow,
+  };
 };

--- a/src/common/utils/stringUtils.ts
+++ b/src/common/utils/stringUtils.ts
@@ -61,3 +61,11 @@ export function uriEncodeTemplateTag(
   }
   return output;
 }
+
+/**
+ * Convert a number into a formatted string with commas and decimals.
+ * This could be replaced with a more robust number formatter library.
+ */
+export function formatNumber(num: number) {
+  return num.toLocaleString();
+}

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -34,12 +34,12 @@ import {
 import { useAppDispatch } from '../../common/hooks';
 import {
   Slider,
-  Menu,
   MenuItem,
   TextField,
   Stack,
   Divider,
   Chip,
+  Paper,
 } from '@mui/material';
 import { useForm } from 'react-hook-form';
 
@@ -98,6 +98,10 @@ export const CollectionDetail = () => {
   const [filterOpen, setFiltersOpen] = useState(false);
   const filterMenuRef = useRef<HTMLButtonElement>(null);
 
+  const handleToggleFilters = () => {
+    setFiltersOpen(!filterOpen);
+  };
+
   if (!collection) return <Loader type="spinner" />;
   return (
     <div className={styles['collection_wrapper']}>
@@ -119,18 +123,16 @@ export const CollectionDetail = () => {
               variant="outlined"
               color={'primary-lighter'}
               textColor={'primary'}
-              onClick={() => {
-                setFiltersOpen(true);
-              }}
+              onClick={handleToggleFilters}
             >
               Filters
             </Button>
-            <FilterMenu
+            {/* <FilterMenu
               collectionId={collection.id}
               anchorEl={filterMenuRef.current}
               open={filterOpen}
               onClose={() => setFiltersOpen(false)}
-            />
+            /> */}
             <Button
               icon={<FontAwesomeIcon icon={faArrowRightArrowLeft} />}
               variant="outlined"
@@ -160,12 +162,20 @@ export const CollectionDetail = () => {
           </div>
         </div>
         <div className={styles['container']}>
+          <FilterMenu
+            collectionId={collection.id}
+            anchorEl={filterMenuRef.current}
+            open={filterOpen}
+            onClose={() => setFiltersOpen(false)}
+          />
           <div className={styles['data_product_detail']}>
             {currDataProduct ? (
-              <DataProduct
-                dataProduct={currDataProduct}
-                collection_id={collection.id}
-              />
+              <Paper variant="outlined">
+                <DataProduct
+                  dataProduct={currDataProduct}
+                  collection_id={collection.id}
+                />
+              </Paper>
             ) : (
               <></>
             )}
@@ -208,17 +218,9 @@ const FilterMenu = (props: {
     dispatch(clearFilter([props.collectionId, context, column]));
   };
 
-  return (
-    <div>
-      <Menu
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        anchorEl={props.anchorEl}
-        open={props.open}
-        onClose={props.onClose}
-      >
+  if (props.open) {
+    return (
+      <div className={styles['filters_panel']}>
         {filterEntries.flatMap(([column, filter]) => {
           const hasVal = Boolean(filter.value);
           const children = [
@@ -240,9 +242,11 @@ const FilterMenu = (props: {
           ];
           return children;
         })}
-      </Menu>
-    </div>
-  );
+      </div>
+    );
+  } else {
+    return null;
+  }
 };
 
 const useCollectionFilters = (collectionId: string | undefined) => {

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -39,7 +39,6 @@ import {
   Stack,
   Divider,
   Chip,
-  Paper,
 } from '@mui/material';
 import { useForm } from 'react-hook-form';
 
@@ -170,12 +169,10 @@ export const CollectionDetail = () => {
           />
           <div className={styles['data_product_detail']}>
             {currDataProduct ? (
-              <Paper variant="outlined">
-                <DataProduct
-                  dataProduct={currDataProduct}
-                  collection_id={collection.id}
-                />
-              </Paper>
+              <DataProduct
+                dataProduct={currDataProduct}
+                collection_id={collection.id}
+              />
             ) : (
               <></>
             )}

--- a/src/features/collections/Collections.module.scss
+++ b/src/features/collections/Collections.module.scss
@@ -11,6 +11,10 @@ $border: 1px solid use-color("base-lighter");
   width: 100%;
 }
 
+.collections-list {
+  padding: 1rem;
+}
+
 .collection_wrapper {
   background-color: use-color("base-lightest");
   display: flex;

--- a/src/features/collections/Collections.module.scss
+++ b/src/features/collections/Collections.module.scss
@@ -94,3 +94,11 @@ $border: 1px solid use-color("base-lighter");
   overflow: auto;
   width: 300px;
 }
+
+.table-toolbar {
+  padding: 1rem;
+}
+
+.pagination-wrapper {
+  padding: 1rem;
+}

--- a/src/features/collections/Collections.module.scss
+++ b/src/features/collections/Collections.module.scss
@@ -4,8 +4,11 @@ $border: 1px solid use-color("base-lighter");
 
 .container {
   background-color: use-color("base-lightest");
+  display: flex;
+  flex: 1;
   height: 100%;
-  padding: 1rem;
+  overflow-y: auto;
+  width: 100%;
 }
 
 .collection_wrapper {
@@ -17,15 +20,18 @@ $border: 1px solid use-color("base-lighter");
 }
 
 .collection_wrapper .collection_main {
+  display: flex;
   flex: 1;
-  overflow: hidden;
+  flex-direction: column;
+  overflow-y: auto;
 }
 
 .collection_detail,
 .data_product_detail {
-  background-color: use-color("white");
-  border: $border;
+  flex: 1;
+  overflow-y: auto;
   padding: 10px;
+  width: 100%;
 }
 
 .detail_header {
@@ -80,4 +86,11 @@ $border: 1px solid use-color("base-lighter");
   margin-bottom: 1rem;
   margin-top: 1rem;
   text-align: center;
+}
+
+.filters_panel {
+  background-color: #fff;
+  flex-shrink: 0;
+  overflow: auto;
+  width: 300px;
 }

--- a/src/features/collections/CollectionsList.tsx
+++ b/src/features/collections/CollectionsList.tsx
@@ -10,28 +10,30 @@ export const CollectionsList = () => {
   const collections = listCollections.useQuery();
   return (
     <div className={classes['container']}>
-      <CardList>
-        {collections.isSuccess
-          ? collections.data?.data.map((collection) => {
-              const detailLink = encodeURIComponent(collection.id);
-              const handleClick = () => navigate(detailLink);
-              return (
-                <Card
-                  key={collection.id}
-                  title={collection.name}
-                  subtitle={collection.ver_tag}
-                  onClick={handleClick}
-                  image={
-                    <img
-                      src={collection.icon_url}
-                      alt={`${collection.name} collection icon`}
-                    />
-                  }
-                />
-              );
-            })
-          : null}
-      </CardList>
+      <div className={classes['collections-list']}>
+        <CardList>
+          {collections.isSuccess
+            ? collections.data?.data.map((collection) => {
+                const detailLink = encodeURIComponent(collection.id);
+                const handleClick = () => navigate(detailLink);
+                return (
+                  <Card
+                    key={collection.id}
+                    title={collection.name}
+                    subtitle={collection.ver_tag}
+                    onClick={handleClick}
+                    image={
+                      <img
+                        src={collection.icon_url}
+                        alt={`${collection.name} collection icon`}
+                      />
+                    }
+                  />
+                );
+              })
+            : null}
+        </CardList>
+      </div>
     </div>
   );
 };

--- a/src/features/collections/data_products/Biolog.tsx
+++ b/src/features/collections/data_products/Biolog.tsx
@@ -25,14 +25,14 @@ export const Biolog: FC<{
   collection_id: string;
 }> = ({ collection_id }) => {
   const dispatch = useAppDispatch();
-  const { table } = useBiolog(collection_id);
+  const { table, count } = useBiolog(collection_id);
   const { firstRow, lastRow } = usePageBounds(table);
 
   return (
     <Paper variant="outlined">
       <div className={classes['table-toolbar']}>
         Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
-        {formatNumber(table.getTotalSize())} genomes
+        {formatNumber(count?.count || 0)} genomes
       </div>
       <HeatMap
         table={table}

--- a/src/features/collections/data_products/Biolog.tsx
+++ b/src/features/collections/data_products/Biolog.tsx
@@ -27,7 +27,7 @@ export const Biolog: FC<{
   const dispatch = useAppDispatch();
   const { table } = useBiolog(collection_id);
   const { firstRow, lastRow } = usePageBounds(table);
-  
+
   return (
     <Paper variant="outlined">
       <div className={classes['table-toolbar']}>

--- a/src/features/collections/data_products/Biolog.tsx
+++ b/src/features/collections/data_products/Biolog.tsx
@@ -12,62 +12,70 @@ import {
   getBiologMeta,
 } from '../../../common/api/collectionsApi';
 import { parseError } from '../../../common/api/utils/parseError';
-import { Pagination } from '../../../common/components/Table';
+import { Pagination, usePageBounds } from '../../../common/components/Table';
 import { useAppDispatch, useBackoffPolling } from '../../../common/hooks';
 import { useAppParam } from '../../params/hooks';
 import { useSelectionId } from '../collectionsSlice';
 import { HeatMap, MAX_HEATMAP_PAGE } from './HeatMap';
+import { formatNumber } from '../../../common/utils/stringUtils';
+import classes from './../Collections.module.scss';
+import { Paper } from '@mui/material';
 
 export const Biolog: FC<{
   collection_id: string;
 }> = ({ collection_id }) => {
   const dispatch = useAppDispatch();
   const { table } = useBiolog(collection_id);
-
+  const { firstRow, lastRow } = usePageBounds(table);
+  
   return (
-    <div>
-      <div>
-        <HeatMap
-          table={table}
-          rowNameAccessor={(row) => row.kbase_id}
-          getCellLabel={async (cell, row, column) => {
-            const { data, error } = await dispatch(
-              getBiologCell.initiate({
-                collection_id,
-                cell_id: cell.cell_id,
-              })
+    <Paper variant="outlined">
+      <div className={classes['table-toolbar']}>
+        Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
+        {formatNumber(table.getTotalSize())} genomes
+      </div>
+      <HeatMap
+        table={table}
+        rowNameAccessor={(row) => row.kbase_id}
+        getCellLabel={async (cell, row, column) => {
+          const { data, error } = await dispatch(
+            getBiologCell.initiate({
+              collection_id,
+              cell_id: cell.cell_id,
+            })
+          );
+          if (!data) {
+            return (
+              <>
+                {'Error loading cell data:'}
+                <br />
+                {error ? parseError(error) : 'Unknown error'}
+              </>
             );
-            if (!data) {
-              return (
+          } else {
+            return (
+              <>
+                Row: {row.kbase_id}
+                <br />
+                Col: {column.columnDef.header}
+                <br />
+                Val: {cell.val.toString()}
                 <>
-                  {'Error loading cell data:'}
-                  <br />
-                  {error ? parseError(error) : 'Unknown error'}
+                  {Object.entries(row.meta as Record<string, string>).map(
+                    ([id, val]) => (
+                      <div key={id}>{`- ${id}:${val}`}</div>
+                    )
+                  )}
                 </>
-              );
-            } else {
-              return (
-                <>
-                  Row: {row.kbase_id}
-                  <br />
-                  Col: {column.columnDef.header}
-                  <br />
-                  Val: {cell.val.toString()}
-                  <>
-                    {Object.entries(row.meta as Record<string, string>).map(
-                      ([id, val]) => (
-                        <div key={id}>{`- ${id}:${val}`}</div>
-                      )
-                    )}
-                  </>
-                </>
-              );
-            }
-          }}
-        />
+              </>
+            );
+          }
+        }}
+      />
+      <div className={classes['pagination-wrapper']}>
         <Pagination table={table} maxPage={MAX_HEATMAP_PAGE} />
       </div>
-    </div>
+    </Paper>
   );
 };
 

--- a/src/features/collections/data_products/GenomeAttribs.tsx
+++ b/src/features/collections/data_products/GenomeAttribs.tsx
@@ -13,6 +13,7 @@ import { CheckBox } from '../../../common/components/CheckBox';
 import {
   Pagination,
   Table,
+  usePageBounds,
   useTableColumns,
 } from '../../../common/components/Table';
 import { useAppDispatch } from '../../../common/hooks';
@@ -26,6 +27,8 @@ import {
   useSelectionId,
 } from '../collectionsSlice';
 import classes from './../Collections.module.scss';
+import { Paper, Stack } from '@mui/material';
+import { formatNumber } from '../../../common/utils/stringUtils';
 
 export const GenomeAttribs: FC<{
   collection_id: string;
@@ -183,45 +186,56 @@ export const GenomeAttribs: FC<{
     },
   });
 
+  const { firstRow, lastRow } = usePageBounds(table);
+
   return (
-    <div>
-      <span>
-        <CheckBox
-          checked={Boolean(filterMatch)}
-          onChange={(e) =>
-            dispatch(setFilterMatch([collection_id, e.currentTarget.checked]))
-          }
-        />{' '}
-        Filter by Match
-      </span>
-
-      <span>
-        <CheckBox
-          checked={Boolean(filterSelection)}
-          onChange={(e) =>
-            dispatch(
-              setFilterSelection([collection_id, e.currentTarget.checked])
-            )
-          }
-        />{' '}
-        Filter by Selection
-      </span>
-
-      <Table
-        table={table}
-        isLoading={isFetching}
-        rowClass={(row) => {
-          // match highlights
-          return matchIndex !== undefined &&
-            matchIndex !== -1 &&
-            row.original[matchIndex]
-            ? classes['match-highlight']
-            : '';
-        }}
-      />
-
-      <Pagination table={table} maxPage={10000 / pagination.pageSize} />
-    </div>
+    <Stack spacing={1}>
+      <Paper variant="outlined">
+        <Stack className={classes['table-toolbar']} direction="row" spacing={1}>
+          <span>
+            Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
+            {formatNumber(table.getTotalSize())} genomes
+          </span>
+          <span>
+            <CheckBox
+              checked={Boolean(filterMatch)}
+              onChange={(e) =>
+                dispatch(
+                  setFilterMatch([collection_id, e.currentTarget.checked])
+                )
+              }
+            />{' '}
+            Filter by Match
+          </span>
+          <span>
+            <CheckBox
+              checked={Boolean(filterSelection)}
+              onChange={(e) =>
+                dispatch(
+                  setFilterSelection([collection_id, e.currentTarget.checked])
+                )
+              }
+            />{' '}
+            Filter by Selection
+          </span>
+        </Stack>
+        <Table
+          table={table}
+          isLoading={isFetching}
+          rowClass={(row) => {
+            // match highlights
+            return matchIndex !== undefined &&
+              matchIndex !== -1 &&
+              row.original[matchIndex]
+              ? classes['match-highlight']
+              : '';
+          }}
+        />
+        <div className={classes['pagination-wrapper']}>
+          <Pagination table={table} maxPage={10000 / pagination.pageSize} />
+        </div>
+      </Paper>
+    </Stack>
   );
 };
 

--- a/src/features/collections/data_products/GenomeAttribs.tsx
+++ b/src/features/collections/data_products/GenomeAttribs.tsx
@@ -194,7 +194,7 @@ export const GenomeAttribs: FC<{
         <Stack className={classes['table-toolbar']} direction="row" spacing={1}>
           <span>
             Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
-            {formatNumber(table.getTotalSize())} genomes
+            {formatNumber(count || 0)} genomes
           </span>
           <span>
             <CheckBox

--- a/src/features/collections/data_products/Microtrait.tsx
+++ b/src/features/collections/data_products/Microtrait.tsx
@@ -24,14 +24,14 @@ export const Microtrait: FC<{
   collection_id: string;
 }> = ({ collection_id }) => {
   const dispatch = useAppDispatch();
-  const { table } = useMicrotrait(collection_id);
+  const { table, count } = useMicrotrait(collection_id);
   const { firstRow, lastRow } = usePageBounds(table);
 
   return (
     <Paper variant="outlined">
       <div className={classes['table-toolbar']}>
         Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
-        {formatNumber(table.getTotalSize())} genomes
+        {formatNumber(count?.count || 0)} genomes
       </div>
       <HeatMap
         table={table}

--- a/src/features/collections/data_products/Microtrait.tsx
+++ b/src/features/collections/data_products/Microtrait.tsx
@@ -12,59 +12,67 @@ import {
   getMicroTraitMeta,
 } from '../../../common/api/collectionsApi';
 import { parseError } from '../../../common/api/utils/parseError';
-import { Pagination } from '../../../common/components/Table';
+import { Pagination, usePageBounds } from '../../../common/components/Table';
 import { useAppDispatch, useBackoffPolling } from '../../../common/hooks';
 import { useSelectionId, useMatchId } from '../collectionsSlice';
 import { HeatMap, MAX_HEATMAP_PAGE } from './HeatMap';
+import classes from './../Collections.module.scss';
+import { Paper } from '@mui/material';
+import { formatNumber } from '../../../common/utils/stringUtils';
 
 export const Microtrait: FC<{
   collection_id: string;
 }> = ({ collection_id }) => {
   const dispatch = useAppDispatch();
   const { table } = useMicrotrait(collection_id);
+  const { firstRow, lastRow } = usePageBounds(table);
 
   return (
-    <div>
-      <div>
-        <HeatMap
-          table={table}
-          rowNameAccessor={(row) => row.kbase_id}
-          getCellLabel={async (cell, row, column) => {
-            const { data, error } = await dispatch(
-              getMicroTraitCell.initiate({
-                collection_id,
-                cell_id: cell.cell_id,
-              })
+    <Paper variant="outlined">
+      <div className={classes['table-toolbar']}>
+        Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
+        {formatNumber(table.getTotalSize())} genomes
+      </div>
+      <HeatMap
+        table={table}
+        rowNameAccessor={(row) => row.kbase_id}
+        getCellLabel={async (cell, row, column) => {
+          const { data, error } = await dispatch(
+            getMicroTraitCell.initiate({
+              collection_id,
+              cell_id: cell.cell_id,
+            })
+          );
+          if (!data) {
+            return (
+              <>
+                {'Error loading cell data:'}
+                <br />
+                {error ? parseError(error) : 'Unknown error'}
+              </>
             );
-            if (!data) {
-              return (
+          } else {
+            return (
+              <>
+                Row: {row.kbase_id}
+                <br />
+                Col: {column.columnDef.header}
+                <br />
+                Val: {cell.val.toString()}
                 <>
-                  {'Error loading cell data:'}
-                  <br />
-                  {error ? parseError(error) : 'Unknown error'}
+                  {data.values.map(({ id, val }) => (
+                    <div key={id}>{`- ${id}:${val}`}</div>
+                  ))}
                 </>
-              );
-            } else {
-              return (
-                <>
-                  Row: {row.kbase_id}
-                  <br />
-                  Col: {column.columnDef.header}
-                  <br />
-                  Val: {cell.val.toString()}
-                  <>
-                    {data.values.map(({ id, val }) => (
-                      <div key={id}>{`- ${id}:${val}`}</div>
-                    ))}
-                  </>
-                </>
-              );
-            }
-          }}
-        />
+              </>
+            );
+          }
+        }}
+      />
+      <div className={classes['pagination-wrapper']}>
         <Pagination table={table} maxPage={MAX_HEATMAP_PAGE} />
       </div>
-    </div>
+    </Paper>
   );
 };
 

--- a/src/features/collections/data_products/SampleAttribs.tsx
+++ b/src/features/collections/data_products/SampleAttribs.tsx
@@ -17,6 +17,7 @@ import { LeafletMap, useLeaflet } from '../../../common/components/Map';
 import {
   Pagination,
   Table,
+  usePageBounds,
   useTableColumns,
 } from '../../../common/components/Table';
 import { useAppDispatch } from '../../../common/hooks';
@@ -27,6 +28,8 @@ import {
   useSelectionId,
 } from '../collectionsSlice';
 import classes from './../Collections.module.scss';
+import { Grid, Paper, Stack } from '@mui/material';
+import { formatNumber } from '../../../common/utils/stringUtils';
 
 export const SampleAttribs: FC<{
   collection_id: string;
@@ -190,6 +193,8 @@ export const SampleAttribs: FC<{
     },
   });
 
+  const { firstRow, lastRow } = usePageBounds(table);
+
   const leaflet = useLeaflet((L, leafletMap) => {
     // Map Init
     leafletMap.setView([37.87722, -122.2506], 13);
@@ -229,42 +234,56 @@ export const SampleAttribs: FC<{
   }, [L, leafletMap, markers]);
 
   return (
-    <div className={classes['dp_columns']}>
-      <div>
-        <span>
-          <CheckBox
-            checked={matchMark}
-            onChange={() => setMatchMark((v) => !v)}
-          />{' '}
-          Show Unmatched
-        </span>
+    <Grid container columnSpacing={1}>
+      <Grid item md={6}>
+        <Paper variant="outlined">
+          <Stack
+            className={classes['table-toolbar']}
+            direction="row"
+            spacing={1}
+          >
+            <span>
+              Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
+              {formatNumber(table.getTotalSize())} genomes
+            </span>
+            <span>
+              <CheckBox
+                checked={matchMark}
+                onChange={() => setMatchMark((v) => !v)}
+              />{' '}
+              Show Unmatched
+            </span>
 
-        <span>
-          <CheckBox
-            checked={selectMark}
-            onChange={() => setSelectMark((v) => !v)}
-          />{' '}
-          Show Unselected
-        </span>
-
-        <Table
-          table={table}
-          isLoading={isFetching}
-          rowClass={(row) => {
-            // match highlights
-            return matchIndex !== undefined &&
-              matchIndex !== -1 &&
-              row.original[matchIndex]
-              ? classes['match-highlight']
-              : '';
-          }}
-        />
-
-        <Pagination table={table} maxPage={10000 / pagination.pageSize} />
-      </div>
-      <div>
-        <LeafletMap height={'800px'} map={leaflet} />
-      </div>
-    </div>
+            <span>
+              <CheckBox
+                checked={selectMark}
+                onChange={() => setSelectMark((v) => !v)}
+              />{' '}
+              Show Unselected
+            </span>
+          </Stack>
+          <Table
+            table={table}
+            isLoading={isFetching}
+            rowClass={(row) => {
+              // match highlights
+              return matchIndex !== undefined &&
+                matchIndex !== -1 &&
+                row.original[matchIndex]
+                ? classes['match-highlight']
+                : '';
+            }}
+          />
+          <div className={classes['pagination-wrapper']}>
+            <Pagination table={table} maxPage={10000 / pagination.pageSize} />
+          </div>
+        </Paper>
+      </Grid>
+      <Grid item md={6}>
+        <Paper variant="outlined">
+          <LeafletMap height={'800px'} map={leaflet} />
+        </Paper>
+      </Grid>
+    </Grid>
   );
 };

--- a/src/features/collections/data_products/SampleAttribs.tsx
+++ b/src/features/collections/data_products/SampleAttribs.tsx
@@ -244,7 +244,7 @@ export const SampleAttribs: FC<{
           >
             <span>
               Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
-              {formatNumber(table.getTotalSize())} genomes
+              {formatNumber(countData?.count || 0)} genomes
             </span>
             <span>
               <CheckBox

--- a/src/features/collections/data_products/TaxaCount.module.scss
+++ b/src/features/collections/data_products/TaxaCount.module.scss
@@ -7,6 +7,7 @@ $gaps: 5px;
   display: flex;
   flex-flow: row nowrap;
   gap: $gaps;
+  padding: 0.5rem;
   width: 100%;
 }
 
@@ -68,4 +69,8 @@ $gaps: 5px;
     }
   }
 
+}
+
+.chart-toolbar {
+  padding: 1rem;
 }

--- a/src/features/collections/data_products/TaxaCount.tsx
+++ b/src/features/collections/data_products/TaxaCount.tsx
@@ -9,6 +9,7 @@ import { useBackoffPolling } from '../../../common/hooks';
 import { snakeCaseToHumanReadable } from '../../../common/utils/stringUtils';
 import { useMatchId, useSelectionId } from '../collectionsSlice';
 import classes from './TaxaCount.module.scss';
+import { Paper, Stack } from '@mui/material';
 
 export const TaxaCount: FC<{
   collection_id: string;
@@ -57,64 +58,68 @@ export const TaxaCount: FC<{
   if (ranksQuery.isLoading || countsQuery.isLoading) return <Loader />;
 
   return (
-    <>
-      <Select
-        value={rank}
-        options={rankOptions}
-        onChange={(opt) => setRank(opt[0])}
-      />
-      <br></br>
-      <div className={classes['figure']}>
-        <div className={classes['name-section']}>
-          {taxa.map(({ name }) => (
-            <Fragment key={name}>
-              <div className={classes['name']}>{name}</div>
-              {matchId ? (
-                <div className={classes['sub-name']}>Matched</div>
-              ) : (
-                <></>
-              )}
-              {selectionId ? (
-                <div className={classes['sub-name']}>Selected</div>
-              ) : (
-                <></>
-              )}
-            </Fragment>
-          ))}
+    <Paper variant="outlined">
+      <Stack spacing={1}>
+        <div className={classes['chart-toolbar']}>
+          <Select
+            value={rank}
+            options={rankOptions}
+            onChange={(opt) => setRank(opt[0])}
+          />
         </div>
-        <div className={classes['bars-section']}>
-          {taxa.map(({ name, count, match_count, sel_count }) => {
-            const width = Math.round((count / max) * 10000) / 100;
-            const matchWidth =
-              Math.round(((match_count || 0) / max) * 10000) / 100;
-            const selWidth = Math.round(((sel_count || 0) / max) * 10000) / 100;
-            return (
+        <div className={classes['figure']}>
+          <div className={classes['name-section']}>
+            {taxa.map(({ name }) => (
               <Fragment key={name}>
-                <Bar width={width} count={count} />
+                <div className={classes['name']}>{name}</div>
                 {matchId ? (
-                  <Bar
-                    className={classes['matched']}
-                    width={matchWidth}
-                    count={match_count || 0}
-                  />
+                  <div className={classes['sub-name']}>Matched</div>
                 ) : (
                   <></>
                 )}
                 {selectionId ? (
-                  <Bar
-                    className={classes['selected']}
-                    width={selWidth}
-                    count={sel_count || 0}
-                  />
+                  <div className={classes['sub-name']}>Selected</div>
                 ) : (
                   <></>
                 )}
               </Fragment>
-            );
-          })}
+            ))}
+          </div>
+          <div className={classes['bars-section']}>
+            {taxa.map(({ name, count, match_count, sel_count }) => {
+              const width = Math.round((count / max) * 10000) / 100;
+              const matchWidth =
+                Math.round(((match_count || 0) / max) * 10000) / 100;
+              const selWidth =
+                Math.round(((sel_count || 0) / max) * 10000) / 100;
+              return (
+                <Fragment key={name}>
+                  <Bar width={width} count={count} />
+                  {matchId ? (
+                    <Bar
+                      className={classes['matched']}
+                      width={matchWidth}
+                      count={match_count || 0}
+                    />
+                  ) : (
+                    <></>
+                  )}
+                  {selectionId ? (
+                    <Bar
+                      className={classes['selected']}
+                      width={selWidth}
+                      count={sel_count || 0}
+                    />
+                  ) : (
+                    <></>
+                  )}
+                </Fragment>
+              );
+            })}
+          </div>
         </div>
-      </div>
-    </>
+      </Stack>
+    </Paper>
   );
 };
 


### PR DESCRIPTION
- Moves Collection filter menu into a panel in the main content area
- Makes filter panel expand to fill height of window and lets users scroll to see additional filters
- Right side of content area is pushed to the right when panel is open
- Elements in data products have consistent panels wrapped around them
- Adds padding around pagination components and table toolbars
- Adds row count text above tables and heatmaps

- [x] Add rowCount to useMicrotrait hook and genome attributes table hook