### PR TITLE
 add narr2 enviroment

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,12 @@
       "public_url": "/"
     },
 
+    "narrative2": {
+      "domain": "narrative2.kbase.us",
+      "legacy": "legacy.narrative2.kbase.us",
+      "public_url": "/"
+    },
+
     "next": {
       "domain": "next.kbase.us",
       "legacy": "legacy.next.kbase.us",

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -288,6 +288,7 @@ const Enviroment: FC = () => {
     ci: faFlask,
     'ci-europa': faFlask,
     'narrative-dev': faWrench,
+    narrative2: faWrench,
     next: faWrench,
     unknown: faQuestionCircle,
   }[env];
@@ -296,6 +297,7 @@ const Enviroment: FC = () => {
     ci: 'CI',
     'ci-europa': 'EUR',
     'narrative-dev': 'NARDEV',
+    narrative2: 'NAR2',
     next: 'NEXT',
     unknown: 'ENV?',
   }[env];

--- a/src/features/layout/layoutSlice.ts
+++ b/src/features/layout/layoutSlice.ts
@@ -7,6 +7,7 @@ const environments = [
   'ci',
   'ci-europa',
   'narrative-dev',
+  'narrative2',
   'next',
   'production',
   'unknown',


### PR DESCRIPTION
Adding section for the `narrative2` environment for testing in a more production-like environment.