### PR TITLE
PUBLIC-2722 Fix Google Re-login bug

### DIFF
--- a/src/common/cookie.ts
+++ b/src/common/cookie.ts
@@ -24,8 +24,6 @@ export function setCookie(
     SameSite?: 'Lax' | 'Strict' | 'None';
   }
 ) {
-  // eslint-disable-next-line no-console
-  console.log('setCookie', { name, value, options });
   if (!name) throw new Error('cannot set unnamed cookie');
   const { expires, path, domain, secure, SameSite } = {
     path: '/',

--- a/src/common/cookie.ts
+++ b/src/common/cookie.ts
@@ -24,6 +24,8 @@ export function setCookie(
     SameSite?: 'Lax' | 'Strict' | 'None';
   }
 ) {
+  // eslint-disable-next-line no-console
+  console.log('setCookie', { name, value, options });
   if (!name) throw new Error('cannot set unnamed cookie');
   const { expires, path, domain, secure, SameSite } = {
     path: '/',

--- a/src/features/auth/authSlice.test.tsx
+++ b/src/features/auth/authSlice.test.tsx
@@ -172,14 +172,13 @@ describe('authSlice', () => {
       );
       await waitFor(() => {
         expect(setTokenCookieMock).toHaveBeenCalledWith('some-token', {
-          domain: '.ci-europa.kbase.us',
           expires: new Date(auth.tokenInfo.expires),
         });
         expect(consoleErrorMock).not.toHaveBeenCalled();
       });
     });
 
-    test('useTokenCookie sets cookie without domain in development mode', async () => {
+    test('useTokenCookie sets cookie in development mode', async () => {
       const processEnv = process.env;
       process.env = { ...processEnv, NODE_ENV: 'development' };
       const auth = {
@@ -333,7 +332,6 @@ describe('authSlice', () => {
       );
       await waitFor(() => {
         expect(setTokenCookieMock).toBeCalledWith('AAAAAA', {
-          domain: '.ci-europa.kbase.us',
           expires: new Date(10),
         });
         expect(clearTokenCookieMock).not.toBeCalled();

--- a/src/features/auth/authSlice.test.tsx
+++ b/src/features/auth/authSlice.test.tsx
@@ -172,7 +172,7 @@ describe('authSlice', () => {
       );
       await waitFor(() => {
         expect(setTokenCookieMock).toHaveBeenCalledWith('some-token', {
-          domain: 'ci-europa.kbase.us',
+          domain: '.ci-europa.kbase.us',
           expires: new Date(auth.tokenInfo.expires),
         });
         expect(consoleErrorMock).not.toHaveBeenCalled();
@@ -333,7 +333,7 @@ describe('authSlice', () => {
       );
       await waitFor(() => {
         expect(setTokenCookieMock).toBeCalledWith('AAAAAA', {
-          domain: 'ci-europa.kbase.us',
+          domain: '.ci-europa.kbase.us',
           expires: new Date(10),
         });
         expect(clearTokenCookieMock).not.toBeCalled();

--- a/src/features/auth/hooks.ts
+++ b/src/features/auth/hooks.ts
@@ -34,13 +34,19 @@ export const useTokenCookie = (
   const dispatch = useAppDispatch();
 
   // Pull token from main cookie. If it exists, and differs from state, try it for auth.
-  const [cookieToken, setCookieToken, clearCookieToken] = useCookie(cookieName);
+  const [cookieToken, setCookieToken, clearCookieToken] = useCookie(
+    cookieName,
+    process.env.NODE_ENV === 'development'
+      ? {}
+      : { domain: `.${process.env.REACT_APP_KBASE_DOMAIN}` }
+  );
+
   const { isSuccess, isFetching, isUninitialized } =
     useTryAuthFromToken(cookieToken);
 
   // Controls for backupCookie
   const [backupCookieToken, setBackupCookieToken, clearBackupCookieToken] =
-    useCookie(backupCookieName);
+    useCookie(backupCookieName, { domain: backupCookieDomain });
 
   // Pull token, expiration, and init info from auth state
   const token = useAppSelector(authToken);
@@ -59,8 +65,6 @@ export const useTokenCookie = (
       !isSuccess &&
       !token
     ) {
-      // eslint-disable-next-line no-console
-      console.log('clearing');
       dispatch(setAuth(null));
       clearCookieToken();
       // clear backup token too, if it exists
@@ -91,9 +95,6 @@ export const useTokenCookie = (
     if (token && expires) {
       setCookieToken(token, {
         expires: new Date(expires),
-        ...(process.env.NODE_ENV === 'development'
-          ? {}
-          : { domain: `.${process.env.REACT_APP_KBASE_DOMAIN}` }),
       });
     } else if (token && !expires) {
       // eslint-disable-next-line no-console
@@ -127,7 +128,6 @@ export const useTokenCookie = (
         console.error('Could not set backup token cookie, missing expire time');
       } else {
         setBackupCookieToken(token, {
-          domain: backupCookieDomain,
           expires: new Date(expires),
         });
       }

--- a/src/features/auth/hooks.ts
+++ b/src/features/auth/hooks.ts
@@ -55,8 +55,6 @@ export const useTokenCookie = (
 
   // Initializes auth for states where useTryAuthFromToken does not set auth
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log({ cookieToken, isUninitialized, isFetching, isSuccess, token });
     // If the cookieToken is present but it failed checks and wont be overwritten by a token in state, clear
     if (
       cookieToken &&

--- a/src/features/auth/hooks.ts
+++ b/src/features/auth/hooks.ts
@@ -64,7 +64,7 @@ export const useTokenCookie = (
         expires: new Date(expires),
         ...(process.env.NODE_ENV === 'development'
           ? {}
-          : { domain: process.env.REACT_APP_KBASE_DOMAIN }),
+          : { domain: `.${process.env.REACT_APP_KBASE_DOMAIN}` }),
       });
     } else if (token && !expires) {
       // eslint-disable-next-line no-console

--- a/src/features/auth/hooks.ts
+++ b/src/features/auth/hooks.ts
@@ -49,6 +49,8 @@ export const useTokenCookie = (
 
   // Initializes auth for states where useTryAuthFromToken does not set auth
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log({ cookieToken, isUninitialized, isFetching, isSuccess, token });
     // If the cookieToken is present but it failed checks and wont be overwritten by a token in state, clear
     if (
       cookieToken &&
@@ -57,6 +59,8 @@ export const useTokenCookie = (
       !isSuccess &&
       !token
     ) {
+      // eslint-disable-next-line no-console
+      console.log('clearing');
       dispatch(setAuth(null));
       clearCookieToken();
       // clear backup token too, if it exists


### PR DESCRIPTION
1. Before this bugfix, Europa did its best to isolate its own TLD cookie from legacy.* domains. However, this was causing a mismatch in the auth state between Europa and Legacy.
2. Cookie expiration in Europa was running AFTER cookie checks in legacy
3. Legacy flow fails for Google if an invalid cookie is present AT ALL during the login/continue flow endpoint, but it wasn't deleted before the flow, as Europa-cookie-clearing was losing the race condition when the intermediate login page (account choice) wasn't present. It was also losing the race condition on the login page itself and redirecting there when cookies were invalid (meaning cookies were never being deleted)
4. Europa no longer "hesitates" to delete bad cookies until after legacy load (resolving the race condition), and makes sure the domain is always specified when clearing the cookie (although this turned out not to be the issue, it is a latent bug)
5. Cookies are also now properly (completely) deleted on logout!

See comments for specific code change locations