### PR TITLE
Fix slider debouncing, fix slider steps, fix slider clear

### DIFF
--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -659,7 +659,11 @@ const RangeFilterControls = ({
         value={sliderPosition}
         min={filter.min_value}
         max={filter.max_value}
-        step={(filter.max_value - filter.min_value) / 100}
+        step={
+          filter.type === 'int'
+            ? 1
+            : (filter.max_value - filter.min_value) / 100
+        }
         marks={[filter.min_value, filter.max_value].map((v) => ({
           value: v,
           label: v,

--- a/src/features/common.ts
+++ b/src/features/common.ts
@@ -2,6 +2,6 @@ export const realname = 'Rosalind Franklin';
 export const usernameRequested = 'rosalind_franklin';
 export const realnameOther = 'Dorothy Hodgkin';
 export const usernameOtherRequested = 'dorothy_hodgkin';
-export const noOp = (...args: unknown[]) => {
+export const noOp = () => {
   /**noOp */
 };

--- a/src/features/common.ts
+++ b/src/features/common.ts
@@ -2,6 +2,6 @@ export const realname = 'Rosalind Franklin';
 export const usernameRequested = 'rosalind_franklin';
 export const realnameOther = 'Dorothy Hodgkin';
 export const usernameOtherRequested = 'dorothy_hodgkin';
-export const noOp = () => {
+export const noOp = (...args: unknown[]) => {
   /**noOp */
 };


### PR DESCRIPTION
Fixes three items from the bug punchlist:

- closest_placement_af and possibly other sliders show errors after sliding and cannot be recovered
  - fixed by setting `step`
- Filter slider handle does not move until have mouse-up
  - fixed by isolating slider state from form/filter state
- Removing filter doesn’t reset the filter UI
  - fixed by adding an effect to filter controls