### PR TITLE
Fix button colors and sample table

### DIFF
--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -130,9 +130,6 @@ export const CollectionDetail = () => {
                 <Button
                   ref={filterMenuRef}
                   icon={<FontAwesomeIcon icon={faFilter} />}
-                  variant="outlined"
-                  color={'primary-lighter'}
-                  textColor={'primary'}
                   onClick={handleToggleFilters}
                 >
                   Filters
@@ -145,9 +142,7 @@ export const CollectionDetail = () => {
             /> */}
                 <Button
                   icon={<FontAwesomeIcon icon={faArrowRightArrowLeft} />}
-                  variant="outlined"
-                  color={match ? 'primary' : 'primary-lighter'}
-                  textColor={match ? 'primary-lighter' : 'primary'}
+                  variant="contained"
                   onClick={() => {
                     setModalView('match');
                     modal?.show();
@@ -159,11 +154,8 @@ export const CollectionDetail = () => {
                 </Button>
                 <Button
                   icon={<FontAwesomeIcon icon={faCircleCheck} />}
-                  variant="outlined"
-                  color={selection.length > 0 ? 'primary' : 'primary-lighter'}
-                  textColor={
-                    selection.length > 0 ? 'primary-lighter' : 'primary'
-                  }
+                  variant={selection.length > 0 ? 'contained' : 'outlined'}
+                  textColor={selection.length > 0 ? 'white' : 'primary'}
                   onClick={() => {
                     setModalView('select');
                     modal?.show();

--- a/src/features/collections/data_products/SampleAttribs.tsx
+++ b/src/features/collections/data_products/SampleAttribs.tsx
@@ -185,7 +185,7 @@ export const SampleAttribs: FC<{
     pageCount: Math.ceil((countData?.count || 0) / pagination.pageSize),
     onPaginationChange: setPagination,
 
-    enableRowSelection: true,
+    enableRowSelection: false,
     onRowSelectionChange: setSelectionFromSamples,
 
     state: {


### PR DESCRIPTION
Button colors had an issue where they were too light to read. This is fixed.

Also, removes checkboxes from the samples table because they can't be selected right now.