### PR TITLE
Fix Export Form

### DIFF
--- a/src/common/api/collectionsApi.ts
+++ b/src/common/api/collectionsApi.ts
@@ -632,11 +632,17 @@ export const collectionsApi = baseApi.injectEndpoints({
       CollectionsResults['exportSelection'],
       CollectionsParams['exportSelection']
     >({
-      query: ({ selection_id, workspace_id, object_name, ws_type, ...body }) =>
+      query: ({
+        selection_id,
+        workspace_id,
+        object_name,
+        ws_type,
+        description,
+      }) =>
         collectionsService({
           method: 'POST',
           url: encode`/selections/${selection_id}/toset/${workspace_id}/obj/${object_name}/type/${ws_type}`,
-          body: body,
+          body: { description },
           headers: {
             authorization: `Bearer ${store.getState().auth.token}`,
           },

--- a/src/common/api/workspaceApi.ts
+++ b/src/common/api/workspaceApi.ts
@@ -30,7 +30,7 @@ interface wsParams {
   deleteWorkspace: { wsId: number };
   getwsNarrative: { upa: string };
   getwsObjectByName: { upa: string };
-  getwsPermissions: { wsId: number };
+  getwsPermissions: { wsIds: number[] };
   listObjects: {
     ids?: number[];
     workspaces?: string[];
@@ -141,10 +141,10 @@ const wsApi = baseApi.injectEndpoints({
       wsResults['getwsPermissions'],
       wsParams['getwsPermissions']
     >({
-      query: ({ wsId }) =>
+      query: ({ wsIds }) =>
         ws({
           method: 'Workspace.get_permissions_mass',
-          params: [{ workspaces: [{ id: wsId }] }],
+          params: [{ workspaces: wsIds.map((wsId) => ({ id: wsId })) }],
         }),
     }),
     listObjects: builder.query<

--- a/src/common/components/Input.tsx
+++ b/src/common/components/Input.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   ComponentProps,
   ReactElement,
+  FocusEventHandler,
 } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -38,13 +39,15 @@ export const Input = forwardRef<HTMLInputElement, InputInterface>(
       getInputContainerClasses()
     );
 
-    const handleFocus = () => {
+    const handleFocus: FocusEventHandler<HTMLInputElement> = (...args) => {
+      if (rest.onFocus) rest.onFocus(...args);
       setInputContainerClasses(
         `${getInputContainerClasses()} ${classes.focus}`
       );
     };
 
-    const handleBlur = () => {
+    const handleBlur: FocusEventHandler<HTMLInputElement> = (...args) => {
+      if (rest.onBlur) rest.onBlur(...args);
       setInputContainerClasses(getInputContainerClasses());
     };
 

--- a/src/features/collections/ExportModal.tsx
+++ b/src/features/collections/ExportModal.tsx
@@ -97,7 +97,7 @@ export const ExportModal = ({ collectionId }: { collectionId: string }) => {
     triggerExport({
       selection_id: selectionId,
       workspace_id: narrative.access_group.toString(),
-      ws_type: 'badtype', //type.value.toString(),
+      ws_type: type.value.toString(),
       object_name: name,
       description: desc,
       match_id: matchId,

--- a/src/features/collections/SelectionModal.tsx
+++ b/src/features/collections/SelectionModal.tsx
@@ -37,7 +37,11 @@ export const SelectionModal = ({
           >
             Clear Selection
           </Button>
-          <Button color="primary" onClick={() => showExport()}>
+          <Button
+            color="primary"
+            onClick={() => showExport()}
+            disabled={!verifiedSelectionId}
+          >
             Save Selection to Narrative
           </Button>
         </>

--- a/src/features/navigator/NarrativeControl/Share.tsx
+++ b/src/features/navigator/NarrativeControl/Share.tsx
@@ -329,7 +329,7 @@ export const Share: FC<{
   const usernameShares = useAppSelector(shares);
   const usernameAuthed = useAppSelector(authUsername);
   const wsId = narrativeDoc.access_group;
-  const wsPermsQuery = getwsPermissions.useQuery({ wsId });
+  const wsPermsQuery = getwsPermissions.useQuery({ wsIds: [wsId] });
   const shareSelectId = useId();
   const [toggleTrigger] = setwsGlobalPermissions.useMutation();
   useEffect(() => {


### PR DESCRIPTION
fixes three punchlist bugs:

- `Don’t show read-only narratives in the export select box`
- `Export form needs improved error states`
- `In export GUI, Data Object Name -> New [Genome | Assembly] Set Object Name`

also fixes input blur/focus handler forwarding and disables the export button in the select modal when there is no selection.

### New form states:

#### Success
<img width="589" alt="Screenshot 2024-03-11 at 3 20 52 PM" src="https://github.com/kbase/ui/assets/5115845/4577c032-ac27-413a-9571-e5cd735bb60e">

#### Validation Error
<img width="597" alt="Screenshot 2024-03-11 at 4 06 14 PM" src="https://github.com/kbase/ui/assets/5115845/bf7da61d-844d-4197-8721-2cbe997b89f9">

#### Server Error (forced this error because I couldn't figure out a valid form state that lead to a server error)
<img width="595" alt="Screenshot 2024-03-11 at 3 29 49 PM" src="https://github.com/kbase/ui/assets/5115845/608813fd-252b-4338-a227-59b7d8d21b8a">
