### PR TITLE
add disabled state for the sign-in button [URO-188] 

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react';
+import { FC, ReactElement, useEffect } from 'react';
 import {
   Navigate,
   Route,
@@ -21,12 +21,14 @@ import {
   detailDataProductPath,
 } from '../features/collections/Collections';
 import {
+  useAppDispatch,
   useAppSelector,
   useFilteredParams,
   usePageTracking,
 } from '../common/hooks';
+import { setLoginControlDisabled } from '../features/layout/layoutSlice';
 
-export const LOGIN_ROUTE = '/legacy/login';
+export const LOGIN_ROUTE = `/${LEGACY_BASE_ROUTE}/login`;
 export const ROOT_REDIRECT_ROUTE = '/narratives';
 
 const Routes: FC = () => {
@@ -34,7 +36,15 @@ const Routes: FC = () => {
   usePageTracking();
   return (
     <RRRoutes>
-      <Route path={`${LEGACY_BASE_ROUTE}/*`} element={<Legacy />} />
+      <Route path={`${LEGACY_BASE_ROUTE}/*`}>
+        {/* disable login controls in contexts for which Login is not a viable or recommended action  */}
+        <Route path={'login'} element={<DisableLogin element={<Legacy />} />} />
+        <Route
+          path={`auth2/login/continue`} // Auth2 plugin login continue page
+          element={<DisableLogin element={<Legacy />} />}
+        />
+        <Route path="*" element={<Legacy />} />
+      </Route>
       <Route
         path="/profile/:usernameRequested/narratives"
         element={<Authed element={<ProfileWrapper />} />}
@@ -114,6 +124,17 @@ export const Authed: FC<{ element: ReactElement }> = ({ element }) => {
     );
 
   return <>{element}</>;
+};
+
+export const DisableLogin: FC<{ element: ReactElement }> = ({ element }) => {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(setLoginControlDisabled(true));
+    return () => {
+      dispatch(setLoginControlDisabled(false));
+    };
+  }, [dispatch, element]);
+  return element;
 };
 
 export const HashRouteRedirect = () => {

--- a/src/features/layout/TopBar.module.scss
+++ b/src/features/layout/TopBar.module.scss
@@ -74,6 +74,10 @@
   svg {
     font-size: 24px;
   }
+
+  &.disabled {
+    color: use-color("disabled-dark");
+  }
 }
 
 .login_menu {

--- a/src/features/layout/TopBar.test.tsx
+++ b/src/features/layout/TopBar.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { createTestStore } from '../../app/store';
+import LoginPrompt from './TopBar';
+
+describe('LoginPrompt component', () => {
+  test('renders successfully with minimal props', () => {
+    const { container } = render(
+      <Provider store={createTestStore()}>
+        <MemoryRouter>
+          <LoginPrompt />
+        </MemoryRouter>
+      </Provider>
+    );
+    const loginButton = container.querySelector('[role="button"]');
+    expect(loginButton).toHaveTextContent('Sign In');
+    expect(loginButton).not.toHaveAttribute('aria-disabled');
+    expect(loginButton).not.toBeDisabled();
+  });
+
+  test('is disabled if on the login path', () => {
+    const { container } = render(
+      <Provider store={createTestStore()}>
+        <MemoryRouter initialEntries={['/dev/legacy/login']}>
+          <LoginPrompt />
+        </MemoryRouter>
+      </Provider>
+    );
+    const loginButton = container.querySelector('[role="button"]');
+    expect(loginButton).toHaveTextContent('Sign In');
+    expect(loginButton).toHaveAttribute('aria-disabled');
+    expect(loginButton).toBeDisabled();
+  });
+
+  test('is disabled if on the login continue path', () => {
+    const { container } = render(
+      <Provider store={createTestStore()}>
+        <MemoryRouter initialEntries={['/dev/legacy/auth2/login/continue']}>
+          <LoginPrompt />
+        </MemoryRouter>
+      </Provider>
+    );
+    const loginButton = container.querySelector('[role="button"]');
+    expect(loginButton).toHaveTextContent('Sign In');
+    expect(loginButton).toHaveAttribute('aria-disabled');
+    expect(loginButton).toBeDisabled();
+  });
+});

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon as FAIcon } from '@fortawesome/react-fontawesome';
 import {
   faBars,
   faEnvelope,
@@ -16,38 +17,20 @@ import {
   faUser,
   faWrench,
 } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon as FAIcon } from '@fortawesome/react-fontawesome';
 import { FC, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
-import { toast } from 'react-hot-toast';
-import { Link } from 'react-router-dom';
-import { LOGIN_ROUTE } from '../../app/Routes';
-import { resetStateAction } from '../../app/store';
-import { revokeToken } from '../../common/api/authService';
-import { getUserProfile } from '../../common/api/userProfileApi';
 import logo from '../../common/assets/logo/46_square.png';
 import { Dropdown } from '../../common/components';
 import { useAppDispatch, useAppSelector } from '../../common/hooks';
 import { authUsername, setAuth } from '../auth/authSlice';
-import { noOp } from '../common';
 import classes from './TopBar.module.scss';
-
-/**
- * A set of url pathname regular expressions which, when matching the current url
- * pathname, cause the login control to be disabled.
- *
- * This is convenient for the Login view, as it helps indicate login is active,
- * and for the "continue" views, which are encountered during sign-in, which
- * clicking the sign-in button would disrupt.
- *
- * In other words, the login button should be disabled in a context for which
- * Login is not a viable or recommended action.
- */
-const LOGIN_CONTROL_DISABLED_WHITELIST = [
-  /\/legacy\/login/,
-  /\/legacy\/auth2\/login\/continue/,
-];
+import { Button } from '@mui/material';
+import { getUserProfile } from '../../common/api/userProfileApi';
+import { revokeToken } from '../../common/api/authService';
+import { toast } from 'react-hot-toast';
+import { noOp } from '../common';
+import { resetStateAction } from '../../app/store';
 
 export default function TopBar() {
   const username = useAppSelector(authUsername);
@@ -73,43 +56,20 @@ export default function TopBar() {
   );
 }
 
-export const LoginPrompt: FC = () => {
-  const location = useLocation();
-  const disabled = LOGIN_CONTROL_DISABLED_WHITELIST.some((path) => {
-    return path.test(location.pathname);
-  });
-
-  if (disabled) {
-    // Mirrors the appearance of the "real" Sign In button below by using the
-    // same display class. NB: We do this because, unfortunately, Link, used for
-    // the real button, does not have a disabled state.
-    return (
-      // Note that although eslint gives this warning, a "button" role is not actually
-      // generated for the button component, at least for the native button.
-      // eslint-disable-next-line jsx-a11y/no-redundant-roles
-      <button
-        className={[classes.login_prompt, classes.disabled].join(' ')}
-        disabled
-        aria-disabled
-        role="button"
-      >
-        <FAIcon icon={faSignIn} />
-        <span>Sign In</span>
-      </button>
-    );
-  }
-
-  // Sign in should be disabled on the sign-in page! The sign-in page may have a search
-  // param suffix, so we split it off.
+const LoginPrompt: FC = () => {
+  const disabled = useAppSelector((state) => state.layout.loginControlDisabled);
   return (
-    <Link
-      role="button"
-      to={{ pathname: LOGIN_ROUTE }}
+    <Button
+      role="link"
+      variant="text"
+      href={'/legacy/login'}
+      disabled={disabled}
+      aria-disabled={disabled}
       className={classes.login_prompt}
     >
       <FAIcon icon={faSignIn} />
       <span>Sign In</span>
-    </Link>
+    </Button>
   );
 };
 

--- a/src/features/layout/TopBar.tsx
+++ b/src/features/layout/TopBar.tsx
@@ -1,4 +1,3 @@
-import { FontAwesomeIcon as FAIcon } from '@fortawesome/react-fontawesome';
 import {
   faBars,
   faEnvelope,
@@ -17,20 +16,38 @@ import {
   faUser,
   faWrench,
 } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon as FAIcon } from '@fortawesome/react-fontawesome';
 import { FC, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
+import { toast } from 'react-hot-toast';
+import { Link } from 'react-router-dom';
+import { LOGIN_ROUTE } from '../../app/Routes';
+import { resetStateAction } from '../../app/store';
+import { revokeToken } from '../../common/api/authService';
+import { getUserProfile } from '../../common/api/userProfileApi';
 import logo from '../../common/assets/logo/46_square.png';
 import { Dropdown } from '../../common/components';
 import { useAppDispatch, useAppSelector } from '../../common/hooks';
 import { authUsername, setAuth } from '../auth/authSlice';
-import classes from './TopBar.module.scss';
-import { Link } from 'react-router-dom';
-import { getUserProfile } from '../../common/api/userProfileApi';
-import { revokeToken } from '../../common/api/authService';
-import { toast } from 'react-hot-toast';
 import { noOp } from '../common';
-import { resetStateAction } from '../../app/store';
+import classes from './TopBar.module.scss';
+
+/**
+ * A set of url pathname regular expressions which, when matching the current url
+ * pathname, cause the login control to be disabled.
+ *
+ * This is convenient for the Login view, as it helps indicate login is active,
+ * and for the "continue" views, which are encountered during sign-in, which
+ * clicking the sign-in button would disrupt.
+ *
+ * In other words, the login button should be disabled in a context for which
+ * Login is not a viable or recommended action.
+ */
+const LOGIN_CONTROL_DISABLED_WHITELIST = [
+  /\/legacy\/login/,
+  /\/legacy\/auth2\/login\/continue/,
+];
 
 export default function TopBar() {
   const username = useAppSelector(authUsername);
@@ -56,12 +73,45 @@ export default function TopBar() {
   );
 }
 
-const LoginPrompt: FC = () => (
-  <Link role="button" to={'/legacy/login'} className={classes.login_prompt}>
-    <FAIcon icon={faSignIn} />
-    <span>Sign In</span>
-  </Link>
-);
+export const LoginPrompt: FC = () => {
+  const location = useLocation();
+  const disabled = LOGIN_CONTROL_DISABLED_WHITELIST.some((path) => {
+    return path.test(location.pathname);
+  });
+
+  if (disabled) {
+    // Mirrors the appearance of the "real" Sign In button below by using the
+    // same display class. NB: We do this because, unfortunately, Link, used for
+    // the real button, does not have a disabled state.
+    return (
+      // Note that although eslint gives this warning, a "button" role is not actually
+      // generated for the button component, at least for the native button.
+      // eslint-disable-next-line jsx-a11y/no-redundant-roles
+      <button
+        className={[classes.login_prompt, classes.disabled].join(' ')}
+        disabled
+        aria-disabled
+        role="button"
+      >
+        <FAIcon icon={faSignIn} />
+        <span>Sign In</span>
+      </button>
+    );
+  }
+
+  // Sign in should be disabled on the sign-in page! The sign-in page may have a search
+  // param suffix, so we split it off.
+  return (
+    <Link
+      role="button"
+      to={{ pathname: LOGIN_ROUTE }}
+      className={classes.login_prompt}
+    >
+      <FAIcon icon={faSignIn} />
+      <span>Sign In</span>
+    </Link>
+  );
+};
 
 const UserMenu: FC = () => {
   const username = useAppSelector(authUsername);

--- a/src/features/layout/layoutSlice.ts
+++ b/src/features/layout/layoutSlice.ts
@@ -17,11 +17,13 @@ interface PageState {
   environment: typeof environments[number];
   pageTitle: string;
   modalDialogId?: string;
+  loginControlDisabled: boolean;
 }
 
 export const initialState: PageState = {
   pageTitle: document.title || 'KBase',
   environment: 'unknown',
+  loginControlDisabled: false,
 };
 
 export const pageSlice = createSlice({
@@ -45,6 +47,9 @@ export const pageSlice = createSlice({
     setPageTitle: (state, action: PayloadAction<string>) => {
       state.pageTitle = action.payload;
     },
+    setLoginControlDisabled: (state, action: PayloadAction<boolean>) => {
+      state.loginControlDisabled = action.payload;
+    },
   },
 });
 
@@ -66,5 +71,9 @@ export const usePageTitle = (title: string) => {
 };
 export default pageSlice.reducer;
 
-export const { setEnvironment, setModalDialogId, setPageTitle } =
-  pageSlice.actions;
+export const {
+  setEnvironment,
+  setModalDialogId,
+  setPageTitle,
+  setLoginControlDisabled,
+} = pageSlice.actions;


### PR DESCRIPTION
# URO-189 - disable sign-in button when on sign-in view

This is a relatively minor regression from kbase-ui behavior, extracted from the larger set of improvements to Europa/kbase-ui integration.

During the sign-in process, the sign-in button should not be available, as it will either be non-functional (pressing it on the sign-page is essentially a no-op), or interrupted the sign-in flow (when on the sign-in continuation/confirmation view it would essentially interrupt the sign-in session without cancelling it).

The solution is to teach the sign-in button rendering code to recognize the url paths on which the sign-in button should not be active. There were a couple of tricky bits to this implementation:

- in development, a prefix `/dev/` is for some reason used, which means that url pathname references cannot be absolute, so the pattern’s used do not assume, for instance, that `/legacy/` is the prefix for the pathname, but is merely present somewhere within it.
- the `Link` component used for the sign-in button, provided by “react router”, does not have a disabled state, so the disabled button is replicates the link component, using an actual html `button` element in a disabled state, and with no events attached.

In addition, a test file was added to ensure this behavior was implemented.