### PR TITLE
Refine and fix bugs in heatmap data products.

### DIFF
--- a/src/common/components/DataView.tsx
+++ b/src/common/components/DataView.tsx
@@ -9,6 +9,25 @@ interface DataViewProps {
   dataObjects: DataObject[];
 }
 
+interface DataViewRowProps {
+  wsId: number;
+  obj: DataObject;
+}
+
+export const DataViewLink: FC<{
+  identifier: string;
+  children?: React.ReactNode;
+  className?: string;
+}> = ({ children, identifier }) => (
+  <a
+    className={`${classes.dataview} ${classes.className}`}
+    href={`/#dataview/${identifier}`}
+    rel="noopener noreferrer"
+  >
+    {children}
+  </a>
+);
+
 const DataView: FC<DataViewProps> = ({ wsId, dataObjects }) => {
   if (!dataObjects?.length) {
     return (
@@ -32,10 +51,6 @@ const DataView: FC<DataViewProps> = ({ wsId, dataObjects }) => {
   );
 };
 
-interface DataViewRowProps {
-  wsId: number;
-  obj: DataObject;
-}
 const DataViewRow: FC<DataViewRowProps> = ({ wsId, obj }) => (
   <div className={classes.dataview_row_outer}>
     <div>
@@ -43,9 +58,9 @@ const DataViewRow: FC<DataViewRowProps> = ({ wsId, obj }) => (
     </div>
     <div className={classes.dataview_row_inner}>
       <div className={classes.dataview}>
-        <a href={`/#dataview/${wsId}/${obj.name}`} rel="noopener noreferrer">
+        <DataViewLink identifier={`${wsId}/${obj.name}`}>
           {obj.name}
-        </a>
+        </DataViewLink>
       </div>
       <div data-testid="readable-type" className={classes.dataview_row_type}>
         {obj.readableType}

--- a/src/common/components/index.tsx
+++ b/src/common/components/index.tsx
@@ -1,9 +1,18 @@
 import { Button } from './Button';
 import { Dropdown } from './Dropdown';
+import { DataViewLink } from './DataView';
 import { Input } from './Input';
 import { Loader } from './Loader';
 import { PlaceholderFactory } from './PlaceholderFactory';
 import { Select, SelectOption } from './Select';
 
-export { Button, Dropdown, Input, Loader, PlaceholderFactory, Select };
+export {
+  Button,
+  DataViewLink,
+  Dropdown,
+  Input,
+  Loader,
+  PlaceholderFactory,
+  Select,
+};
 export type { SelectOption };

--- a/src/features/collections/ExportModal.tsx
+++ b/src/features/collections/ExportModal.tsx
@@ -1,3 +1,4 @@
+import { Alert, Stack } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import {
   exportSelection,
@@ -7,15 +8,15 @@ import {
 import { getNarratives } from '../../common/api/searchApi';
 import { Select, Input, Button, SelectOption } from '../../common/components';
 import { uriEncodeTemplateTag as encode } from '../../common/utils/stringUtils';
-import { Modal } from '../layout/Modal';
-import { useAppParam } from '../params/hooks';
-import { useSelectionId } from './collectionsSlice';
-import { useParamsForNarrativeDropdown } from './hooks';
-import { Alert, Stack } from '@mui/material';
-import classes from './Collections.module.scss';
+import { DataViewLink } from '../../common/components';
 import { useAppSelector } from '../../common/hooks';
 import { getwsPermissions } from '../../common/api/workspaceApi';
 import { NarrativeDoc } from '../../common/types/NarrativeDoc';
+import { useAppParam } from '../params/hooks';
+import { Modal } from '../layout/Modal';
+import { useSelectionId } from './collectionsSlice';
+import classes from './Collections.module.scss';
+import { useParamsForNarrativeDropdown } from './hooks';
 
 export const ExportModal = ({ collectionId }: { collectionId: string }) => {
   const selectionId = useSelectionId(collectionId);
@@ -187,9 +188,9 @@ export const ExportModal = ({ collectionId }: { collectionId: string }) => {
                   </a>
                 </li>
                 <li>
-                  <a href={`/#dataview/${exportResult.data.set.upa}`}>
+                  <DataViewLink identifier={exportResult.data.set.upa}>
                     Go to DataView
-                  </a>
+                  </DataViewLink>
                 </li>
               </ul>
             </Alert>

--- a/src/features/collections/data_products/Biolog.tsx
+++ b/src/features/collections/data_products/Biolog.tsx
@@ -1,3 +1,4 @@
+import { Paper } from '@mui/material';
 import {
   getCoreRowModel,
   getPaginationRowModel,
@@ -12,14 +13,14 @@ import {
   getBiologMeta,
 } from '../../../common/api/collectionsApi';
 import { parseError } from '../../../common/api/utils/parseError';
+import { DataViewLink } from '../../../common/components';
 import { Pagination, usePageBounds } from '../../../common/components/Table';
 import { useAppDispatch, useBackoffPolling } from '../../../common/hooks';
+import { formatNumber } from '../../../common/utils/stringUtils';
 import { useAppParam } from '../../params/hooks';
+import classes from '../Collections.module.scss';
 import { useGenerateSelectionId } from '../collectionsSlice';
 import { HeatMap, HeatMapCallback, MAX_HEATMAP_PAGE } from './HeatMap';
-import { formatNumber } from '../../../common/utils/stringUtils';
-import classes from './../Collections.module.scss';
-import { Paper } from '@mui/material';
 
 export const Biolog: FC<{
   collection_id: string;
@@ -47,7 +48,7 @@ export const Biolog: FC<{
       );
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error('Error getting MicroTraitCell data.');
+      console.error('Error getting BiologCell data.');
       return <></>;
     }
     const { data, error } = response;
@@ -64,7 +65,10 @@ export const Biolog: FC<{
         <>
           Type: {column.columnDef.meta?.type}
           <hr />
-          Row: {row.kbase_id}
+          Row: (
+          <DataViewLink identifier={row.kbase_id}>
+            {row.kbase_id}
+          </DataViewLink>) {row.kbase_display_name}
           <br />
           Col: {column.columnDef.header}
           <br />
@@ -213,7 +217,7 @@ const useBiolog = (collection_id: string | undefined) => {
 
   const table = useReactTable<RowDatum>({
     data: biolog?.data || [],
-    getRowId: (row) => String(row.kbase_id),
+    getRowId: (row) => String(row.kbase_display_name),
     columns: useMemo(
       () =>
         (meta?.categories ?? []).slice(0, 30).map((category) => {

--- a/src/features/collections/data_products/HeatMap.module.scss
+++ b/src/features/collections/data_products/HeatMap.module.scss
@@ -105,6 +105,14 @@ See the mouseout handler in the <HeatMap /> component.
   z-index: 1;
 }
 
+.tooltip a {
+  color: use-color("accent-cool-light");
+}
+
+.tooltip a:visited {
+  color: use-color("accent-cool");
+}
+
 .trait-names {
   display: flex;
   flex-flow: row nowrap;

--- a/src/features/collections/data_products/Microtrait.tsx
+++ b/src/features/collections/data_products/Microtrait.tsx
@@ -1,3 +1,4 @@
+import { Paper } from '@mui/material';
 import {
   getCoreRowModel,
   getPaginationRowModel,
@@ -12,13 +13,15 @@ import {
   getMicroTraitMeta,
 } from '../../../common/api/collectionsApi';
 import { parseError } from '../../../common/api/utils/parseError';
+import { DataViewLink } from '../../../common/components';
 import { Pagination, usePageBounds } from '../../../common/components/Table';
-import { useMatchId, useGenerateSelectionId } from '../collectionsSlice';
 import { useAppDispatch, useBackoffPolling } from '../../../common/hooks';
-import { HeatMap, HeatMapCallback, MAX_HEATMAP_PAGE } from './HeatMap';
-import classes from './../Collections.module.scss';
-import { Paper } from '@mui/material';
 import { formatNumber } from '../../../common/utils/stringUtils';
+import classes from '../Collections.module.scss';
+import { useMatchId, useGenerateSelectionId } from '../collectionsSlice';
+import { HeatMap, HeatMapCallback, MAX_HEATMAP_PAGE } from './HeatMap';
+
+const getUPAFromEncoded = (encoded: string) => encoded.replaceAll('_', '/');
 
 export const Microtrait: FC<{
   collection_id: string;
@@ -63,7 +66,11 @@ export const Microtrait: FC<{
         <>
           Type: {column.columnDef.meta?.type}
           <hr />
-          Row: ({row.kbase_id}) {row.kbase_display_name}
+          Row: (
+          <DataViewLink identifier={getUPAFromEncoded(row.kbase_id)}>
+            {getUPAFromEncoded(row.kbase_id)}
+          </DataViewLink>
+          ) {row.kbase_display_name}
           <br />
           Col: {column.columnDef.header}
           <br />


### PR DESCRIPTION
This PR adds dataview links to heatmap tooltips. It also abbreviates row and column names in the heatmap. The full names are included in the tooltip. These abbreviations are not always unique, and plotly performs poorly in that case, so a zero-width workaround is included to fix this issue.