### PR TITLE
Switch context tabs and filters positions in layout hierarchy

### DIFF
--- a/src/common/components/Table.module.scss
+++ b/src/common/components/Table.module.scss
@@ -34,21 +34,26 @@ $header-height: 2em;
 }
 
 .pagination {
-  align-items: stretch;
-  display: flex;
-  flex-flow: row nowrap;
-  gap: 0.333em;
-  justify-content: flex-start;
-  max-width: 20em;
+  display: block;
+  text-align: right;
 
   * {
-    flex: 1 1 2.25em;
-    min-width: fit-content;
+    display: inline-block;
+    margin-left: 0.5rem;
   }
 
-  *:first-child,
-  *:last-child {
-    flex: 0 1 2.25em;
+  *:first-child {
+    margin-left: 0;
+  }
+
+  [disabled] {
+    color: #000;
+  }
+
+  .selected {
+    background-color: use-color("mid-green-light");
+    color: #000;
+    opacity: 1;
   }
 }
 

--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -165,7 +165,7 @@ export const Pagination = <Datum,>({
   if (buttons[0] !== start) {
     buttons[0] = start;
     buttons[1] = (
-      <Button key="etc-start" color="base" disabled>
+      <Button key="etc-start" color="gray" disabled>
         {'...'}
       </Button>
     );
@@ -173,7 +173,7 @@ export const Pagination = <Datum,>({
   buttons.unshift(
     <Button
       className={classNamePagination}
-      color="base"
+      color="gray"
       disabled={!table.getCanPreviousPage()}
       key="prev"
       onClick={() => table.previousPage()}
@@ -189,7 +189,7 @@ export const Pagination = <Datum,>({
       <Button
         key="etc-end"
         className={classNamePagination}
-        color="base"
+        color="gray"
         disabled
       >
         {'...'}
@@ -199,7 +199,7 @@ export const Pagination = <Datum,>({
   buttons.push(
     <Button
       className={classNamePagination}
-      color="base"
+      color="gray"
       disabled={!table.getCanNextPage() || curr >= maxPage}
       key="next"
       onClick={() => table.nextPage()}
@@ -210,8 +210,10 @@ export const Pagination = <Datum,>({
   const buttonList = buttons.map((button, ix) =>
     typeof button === 'number' ? (
       <Button
-        className={classNamePagination}
-        color="base"
+        className={`${classNamePagination} ${
+          button === curr ? classes.selected : ''
+        }`}
+        color="gray"
         disabled={button === curr || button > maxPage}
         hidden={button > maxPage} // Hides the max page when we can't display it
         key={button}

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -229,29 +229,6 @@ export const CollectionDetail = () => {
             }}
           />
           <div className={styles['data_product_detail']}>
-            <Stack
-              className={styles['filter-controls']}
-              direction="row"
-              spacing={2}
-              alignItems="center"
-            >
-              <Button
-                hidden={!showFilterButton}
-                ref={filterMenuRef}
-                icon={<FontAwesomeIcon icon={faSliders} />}
-                onClick={handleToggleFilters}
-              >
-                Filters
-              </Button>
-              <div className={styles['filter-chips-label']}>
-                {filterEntries ? filterEntries.length : '0'} active{' '}
-                {filterEntries && filterEntries.length !== 1
-                  ? 'filters'
-                  : 'filter'}
-                {filterEntries && filterEntries.length > 0 ? ':' : ''}
-              </div>
-              <FilterChips collectionId={collection.id} />
-            </Stack>
             {showOverview ? (
               <CollectionOverview
                 collection_id={collection.id}
@@ -259,10 +236,35 @@ export const CollectionDetail = () => {
                 modal={modal}
               />
             ) : currDataProduct ? (
-              <DataProduct
-                dataProduct={currDataProduct}
-                collection_id={collection.id}
-              />
+              <>
+                <Stack
+                  className={styles['filter-controls']}
+                  direction="row"
+                  spacing={2}
+                  alignItems="center"
+                >
+                  <Button
+                    hidden={!showFilterButton}
+                    ref={filterMenuRef}
+                    icon={<FontAwesomeIcon icon={faSliders} />}
+                    onClick={handleToggleFilters}
+                  >
+                    Filters
+                  </Button>
+                  <div className={styles['filter-chips-label']}>
+                    {filterEntries ? filterEntries.length : '0'} active{' '}
+                    {filterEntries && filterEntries.length !== 1
+                      ? 'filters'
+                      : 'filter'}
+                    {filterEntries && filterEntries.length > 0 ? ':' : ''}
+                  </div>
+                  <FilterChips collectionId={collection.id} />
+                </Stack>
+                <DataProduct
+                  dataProduct={currDataProduct}
+                  collection_id={collection.id}
+                />
+              </>
             ) : (
               <></>
             )}

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -178,24 +178,26 @@ export const CollectionDetail = () => {
             <>
               <div className={styles['collection_toolbar']}>
                 <Stack direction="row" spacing={1}>
-                  <Input
-                    hidden={!showSearch}
-                    className={styles['search-box']}
-                    placeholder="Search genomes by classification"
-                  />
-                  <Button
-                    hidden={!showMatchButton}
-                    icon={<FontAwesomeIcon icon={faArrowRightArrowLeft} />}
-                    variant="text"
-                    onClick={() => {
-                      setModalView('match');
-                      modal?.show();
-                    }}
-                  >
-                    {match
-                      ? `Matching by ${MATCHER_LABELS.get(match.matcher_id)}`
-                      : `Match My Data`}
-                  </Button>
+                  {showSearch && (
+                    <Input
+                      className={styles['search-box']}
+                      placeholder="Search genomes by classification"
+                    />
+                  )}
+                  {showMatchButton && (
+                    <Button
+                      icon={<FontAwesomeIcon icon={faArrowRightArrowLeft} />}
+                      variant="text"
+                      onClick={() => {
+                        setModalView('match');
+                        modal?.show();
+                      }}
+                    >
+                      {match
+                        ? `Matching by ${MATCHER_LABELS.get(match.matcher_id)}`
+                        : `Match My Data`}
+                    </Button>
+                  )}
                 </Stack>
                 <Button
                   icon={<FontAwesomeIcon icon={faFileExport} />}
@@ -237,29 +239,30 @@ export const CollectionDetail = () => {
               />
             ) : currDataProduct ? (
               <>
-                <Stack
-                  className={styles['filter-controls']}
-                  direction="row"
-                  spacing={2}
-                  alignItems="center"
-                >
-                  <Button
-                    hidden={!showFilterButton}
-                    ref={filterMenuRef}
-                    icon={<FontAwesomeIcon icon={faSliders} />}
-                    onClick={handleToggleFilters}
+                {showFilterButton && (
+                  <Stack
+                    className={styles['filter-controls']}
+                    direction="row"
+                    spacing={2}
+                    alignItems="center"
                   >
-                    Filters
-                  </Button>
-                  <div className={styles['filter-chips-label']}>
-                    {filterEntries ? filterEntries.length : '0'} active{' '}
-                    {filterEntries && filterEntries.length !== 1
-                      ? 'filters'
-                      : 'filter'}
-                    {filterEntries && filterEntries.length > 0 ? ':' : ''}
-                  </div>
-                  <FilterChips collectionId={collection.id} />
-                </Stack>
+                    <Button
+                      ref={filterMenuRef}
+                      icon={<FontAwesomeIcon icon={faSliders} />}
+                      onClick={handleToggleFilters}
+                    >
+                      Filters
+                    </Button>
+                    <div className={styles['filter-chips-label']}>
+                      {filterEntries ? filterEntries.length : '0'} active{' '}
+                      {filterEntries && filterEntries.length !== 1
+                        ? 'filters'
+                        : 'filter'}
+                      {filterEntries && filterEntries.length > 0 ? ':' : ''}
+                    </div>
+                    <FilterChips collectionId={collection.id} />
+                  </Stack>
+                )}
                 <DataProduct
                   dataProduct={currDataProduct}
                   collection_id={collection.id}

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -393,29 +393,15 @@ const FilterMenu = ({
   } = useFilterEntries(collectionId);
 
   /**
-   * Store category expanded state in an object
+   * Store expanded category string, empty string for none expanded
    */
-  const [expandedByCategory, setExpandedByCategory] = useState(() => {
-    const expanded: { [key: string]: boolean } = {};
-    categorizedFilters.forEach((category) => {
-      expanded[category.category] = false;
-    });
-    return expanded;
-  });
+  const [expandedCategory, setExpandedCategory] = useState('');
 
   /**
    * Only allow one category to be expanded at a time.
    */
   const handleExpand = (expanded: boolean, category: string) => {
-    const newValue = { ...expandedByCategory };
-    Object.keys(expandedByCategory).forEach((c) => {
-      if (expanded && c === category) {
-        newValue[c] = true;
-      } else {
-        newValue[c] = false;
-      }
-    });
-    setExpandedByCategory(newValue);
+    setExpandedCategory(expanded ? category : '');
   };
 
   if (open) {
@@ -448,7 +434,7 @@ const FilterMenu = ({
                 key={`${category.category}-${context}`}
                 className={styles['filter-category']}
                 elevation={0}
-                expanded={expandedByCategory[category.category]}
+                expanded={category.category === expandedCategory}
                 onChange={(e, expanded) =>
                   handleExpand(expanded, category.category)
                 }

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -187,7 +187,7 @@ export const CollectionDetail = () => {
                   {showMatchButton && (
                     <Button
                       icon={<FontAwesomeIcon icon={faArrowRightArrowLeft} />}
-                      variant="text"
+                      color="accent-warm"
                       onClick={() => {
                         setModalView('match');
                         modal?.show();

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -187,7 +187,7 @@ export const CollectionDetail = () => {
                   {showMatchButton && (
                     <Button
                       icon={<FontAwesomeIcon icon={faArrowRightArrowLeft} />}
-                      color="accent-warm"
+                      color="accent-warm-light"
                       onClick={() => {
                         setModalView('match');
                         modal?.show();

--- a/src/features/collections/CollectionDetail.tsx
+++ b/src/features/collections/CollectionDetail.tsx
@@ -186,7 +186,7 @@ export const CollectionDetail = () => {
                   <Button
                     hidden={!showMatchButton}
                     icon={<FontAwesomeIcon icon={faArrowRightArrowLeft} />}
-                    variant="contained"
+                    variant="text"
                     onClick={() => {
                       setModalView('match');
                       modal?.show();
@@ -194,7 +194,7 @@ export const CollectionDetail = () => {
                   >
                     {match
                       ? `Matching by ${MATCHER_LABELS.get(match.matcher_id)}`
-                      : `Match my Data`}
+                      : `Match My Data`}
                   </Button>
                 </Stack>
                 <Button

--- a/src/features/collections/CollectionOverview.tsx
+++ b/src/features/collections/CollectionOverview.tsx
@@ -87,6 +87,15 @@ export const CollectionOverview: FC<{
               color="text.secondary"
               gutterBottom
             >
+              Collection Name
+            </Typography>
+            <div>{collection.name}</div>
+            <br></br>
+            <Typography
+              sx={{ fontSize: 12 }}
+              color="text.secondary"
+              gutterBottom
+            >
               Updated On
             </Typography>
             <div>

--- a/src/features/collections/Collections.module.scss
+++ b/src/features/collections/Collections.module.scss
@@ -85,12 +85,16 @@ $border: 1px solid use-color("base-lighter");
   background-color: use-color("white");
   border-bottom: 1px solid use-color("silver");
   min-width: 600px;
-  padding: 1rem;
+  padding: 1rem 1rem 0;
 }
 
 .detail_header h2 {
   margin-bottom: 0.5rem;
   margin-top: 0;
+}
+
+.context-tabs {
+  margin-top: 0.5rem;
 }
 
 .match-highlight {
@@ -105,6 +109,17 @@ $border: 1px solid use-color("base-lighter");
 
 .search-box {
   width: 400px;
+}
+
+.filter-controls {
+  background-color: use-color("white");
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+}
+
+.filter-chips-label {
+  color: use-color("base-dark");
 }
 
 .detail_content {

--- a/src/features/collections/MatchModal.tsx
+++ b/src/features/collections/MatchModal.tsx
@@ -420,7 +420,7 @@ const CreateMatch = ({ collectionId }: { collectionId: string }) => {
             )}
           </Stack>
           <Stack spacing={1}>
-            <label htmlFor={idNarrative}>Narrative Test</label>
+            <label htmlFor={idNarrative}>Narrative</label>
             <Select
               id={idNarrative}
               disabled={!matcherSelected}

--- a/src/features/collections/data_products/GenomeAttribs.tsx
+++ b/src/features/collections/data_products/GenomeAttribs.tsx
@@ -324,11 +324,14 @@ export const GenomeAttribs: FC<{
             className={classes['table-toolbar']}
             direction="row"
             spacing={1}
+            justifyContent="space-between"
+            alignItems="center"
           >
             <span>
               Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
               {formatNumber(count || 0)} genomes
             </span>
+            <Pagination table={table} maxPage={10000 / pagination.pageSize} />
           </Stack>
           <Table
             table={table}

--- a/src/features/collections/data_products/GenomeAttribs.tsx
+++ b/src/features/collections/data_products/GenomeAttribs.tsx
@@ -279,7 +279,7 @@ export const GenomeAttribs: FC<{
         <Paper
           elevation={0}
           sx={{
-            height: '400px',
+            height: '350px',
             minWidth: '350px',
             padding: '1px',
             position: 'relative',
@@ -303,7 +303,7 @@ export const GenomeAttribs: FC<{
         <Paper
           elevation={0}
           sx={{
-            height: '400px',
+            height: '350px',
             minWidth: '350px',
             padding: '1px',
             position: 'relative',

--- a/src/features/collections/data_products/GenomeAttribs.tsx
+++ b/src/features/collections/data_products/GenomeAttribs.tsx
@@ -277,7 +277,7 @@ export const GenomeAttribs: FC<{
     <Grid container spacing={1}>
       <Grid item md={6}>
         <Paper
-          variant="outlined"
+          elevation={0}
           sx={{
             height: '400px',
             minWidth: '350px',
@@ -301,7 +301,7 @@ export const GenomeAttribs: FC<{
       </Grid>
       <Grid item md={6}>
         <Paper
-          variant="outlined"
+          elevation={0}
           sx={{
             height: '400px',
             minWidth: '350px',
@@ -319,7 +319,7 @@ export const GenomeAttribs: FC<{
         </Paper>
       </Grid>
       <Grid item xs={12}>
-        <Paper variant="outlined">
+        <Paper elevation={0}>
           <Stack
             className={classes['table-toolbar']}
             direction="row"

--- a/src/features/collections/data_products/SampleAttribs.tsx
+++ b/src/features/collections/data_products/SampleAttribs.tsx
@@ -277,21 +277,6 @@ export const SampleAttribs: FC<{
                 Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
                 {formatNumber(countData?.count || 0)} samples
               </span>
-              <span>
-                <CheckBox
-                  checked={matchMark}
-                  onChange={() => setMatchMark((v) => !v)}
-                />{' '}
-                Show Unmatched
-              </span>
-
-              <span>
-                <CheckBox
-                  checked={selectMark}
-                  onChange={() => setSelectMark((v) => !v)}
-                />{' '}
-                Show Unselected
-              </span>
             </Stack>
             <Pagination table={table} maxPage={10000 / pagination.pageSize} />
           </Stack>

--- a/src/features/collections/data_products/SampleAttribs.tsx
+++ b/src/features/collections/data_products/SampleAttribs.tsx
@@ -252,26 +252,31 @@ export const SampleAttribs: FC<{
             className={classes['table-toolbar']}
             direction="row"
             spacing={1}
+            justifyContent="space-between"
+            alignItems="center"
           >
-            <span>
-              Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
-              {formatNumber(countData?.count || 0)} genomes
-            </span>
-            <span>
-              <CheckBox
-                checked={matchMark}
-                onChange={() => setMatchMark((v) => !v)}
-              />{' '}
-              Show Unmatched
-            </span>
+            <Stack direction="row" spacing={1}>
+              <span>
+                Showing {formatNumber(firstRow)} - {formatNumber(lastRow)} of{' '}
+                {formatNumber(countData?.count || 0)} genomes
+              </span>
+              <span>
+                <CheckBox
+                  checked={matchMark}
+                  onChange={() => setMatchMark((v) => !v)}
+                />{' '}
+                Show Unmatched
+              </span>
 
-            <span>
-              <CheckBox
-                checked={selectMark}
-                onChange={() => setSelectMark((v) => !v)}
-              />{' '}
-              Show Unselected
-            </span>
+              <span>
+                <CheckBox
+                  checked={selectMark}
+                  onChange={() => setSelectMark((v) => !v)}
+                />{' '}
+                Show Unselected
+              </span>
+            </Stack>
+            <Pagination table={table} maxPage={10000 / pagination.pageSize} />
           </Stack>
           <Table
             table={table}

--- a/src/features/collections/data_products/TaxaCount.module.scss
+++ b/src/features/collections/data_products/TaxaCount.module.scss
@@ -7,7 +7,7 @@ $gaps: 5px;
   display: flex;
   flex-flow: row nowrap;
   gap: $gaps;
-  padding: 0.5rem;
+  padding: 0 1rem 1rem;
   width: 100%;
 }
 
@@ -59,7 +59,7 @@ $gaps: 5px;
 
   &.matched {
     .bar {
-      background: use-color("secondary");
+      background: use-color("accent-warm");
     }
   }
 


### PR DESCRIPTION
**New Context Tab Layout**

This moves the context tabs into the top detail header and the filters down into the main data product content area. The goal is to make it more clear that the filters applied can be different between the different tabs (All, Matched, Selected).

**Other UI Modifications**

- Pagination re-styled and duplicated on top and bottom of tables
- Match button color change
- Changed matched bar color in taxa chart to match button and row highlight