### PR TITLE
Make Collections NavItem public

### DIFF
--- a/src/features/layout/LeftNavBar.tsx
+++ b/src/features/layout/LeftNavBar.tsx
@@ -43,6 +43,13 @@ const LeftNavBar: FC = () => {
           icon={faBullhorn}
           badge={feeds?.unseen.global}
         />
+        <NavItem
+          path="/collections"
+          desc="Collections"
+          icon={faLayerGroup}
+          badge={'beta'}
+          badgeColor={'primary'}
+        />
         <DevNav />
       </ul>
     </nav>
@@ -51,6 +58,7 @@ const LeftNavBar: FC = () => {
 
 const devDomains = new Set(['', 'ci-europa.kbase.us']);
 
+/** Hidden navigation items for devs */
 const DevNav: FC = () => {
   const me = useAppSelector(authMe);
   useAuthMe();
@@ -62,13 +70,14 @@ const DevNav: FC = () => {
   if (!me || !dev) return <></>;
   return (
     <>
+      {/* Nothing here now, heres an example:
       <NavItem
         path="/collections"
         desc="Collections"
         icon={faLayerGroup}
         badge={'beta'}
         badgeColor={'primary'}
-      />
+      /> */}
     </>
   );
 };


### PR DESCRIPTION
Enable collections for everyone. The `UI_COLLECTIONS` custom role now has no meaning.