### PR TITLE
Add Oxygen Google Font headers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,9 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="icon" href="https://www.kbase.us/wp-content/uploads/sites/6/2020/08/kbase-favicon-32-bgwhite_rounded_corners.png" sizes="192x192" />
     <link rel="apple-touch-icon" href="https://www.kbase.us/wp-content/uploads/sites/6/2020/08/kbase-favicon-32-bgwhite_rounded_corners.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Oxygen:wght@300;400;700&display=swap" rel="stylesheet">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
Use a Google CDN to serve our web font so that it is easier to distinguish `l` from `I`.