### PR TITLE
Expand table loader overlay and add bg animation

### DIFF
--- a/src/common/components/Table.module.scss
+++ b/src/common/components/Table.module.scss
@@ -57,14 +57,24 @@ $header-height: 2em;
   }
 }
 
+@keyframes table-loading {
+  from {background-color: use-color("base-light");}
+  to {background-color: use-color("base");}
+}
+
 .table-wrapper .loader {
   align-items: center;
-  background-color: use-rgba-color("grey", 0.8);
+  animation-direction: alternate;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-name: table-loading;
+  animation-timing-function: linear;
   bottom: 0;
   color: use-color("white");
-  display: flex;
   justify-content: center;
   left: 0;
+  opacity: 0.5;
+  padding: 1rem;
   pointer-events: none;
   position: absolute;
   right: 0;
@@ -75,6 +85,7 @@ $header-height: 2em;
   border-collapse: separate;
   border-spacing: 0;
   height: 100%;
+  position: relative;
   width: 100%;
 
   thead {

--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -114,15 +114,15 @@ export const Table = <Datum,>({
             {table.getRowModel().rows.length < 1 ? <tr /> : <></>}
           </tbody>
           {shouldRenderFooter ? <TableFooter table={table} /> : <></>}
+          <Loader
+            loading={isLoading}
+            render={
+              <div className={classes['loader']} data-testid="table-loader">
+                <FAIcon icon={faSpinner} spin size={'2x'} />
+              </div>
+            }
+          />
         </table>
-        <Loader
-          loading={isLoading}
-          render={
-            <div className={classes['loader']} data-testid="table-loader">
-              <FAIcon icon={faSpinner} spin size={'2x'} />
-            </div>
-          }
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes bug causing table loader overlay not to expand over the scrollable parts of the table. The table overlay now expands across all the columns, but the loader icon is still only visible on the far left of the table. To make sure users still know that the table is loading when scrolled to the right, I added a background animation.