### PR TITLE
Initial steps toward migrating the Feeds page to native Europa

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -8,6 +8,7 @@ import {
 
 import Legacy, { LEGACY_BASE_ROUTE } from '../features/legacy/Legacy';
 import { Fallback } from '../features/legacy/IFrameFallback';
+import Feeds, { feedsPath } from '../features/feeds/Feeds';
 import Navigator, {
   navigatorPath,
   navigatorPathWithCategory,
@@ -62,6 +63,9 @@ const Routes: FC = () => {
         element={<Authed element={<Navigator />} />}
       />
       <Route path="/narratives" element={<Authed element={<Navigator />} />} />
+
+      {/* Feeds */}
+      <Route path={feedsPath} element={<Authed element={<Feeds />} />} />
 
       {/* Collections */}
       <Route path="/collections">

--- a/src/features/feeds/FeedTabs.test.tsx
+++ b/src/features/feeds/FeedTabs.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter as Router } from 'react-router-dom';
+import { createTestStore } from '../../app/store';
+import FeedTabs, { FeedTabsProps } from './FeedTabs';
+
+const testProps: FeedTabsProps = {
+  userId: 'some_user',
+  isAdmin: false,
+  feeds: {
+    feed1: {
+      name: 'A feed',
+      feed: [],
+      unseen: 0,
+    },
+  },
+};
+
+test('FeedTabs renders', async () => {
+  const { container } = render(
+    <Provider store={createTestStore()}>
+      <Router>
+        <FeedTabs {...testProps}/>
+      </Router>
+    </Provider>
+  );
+  expect(container).toBeTruthy();
+  expect(container.textContent).toMatch(testProps.userId);
+});

--- a/src/features/feeds/FeedTabs.tsx
+++ b/src/features/feeds/FeedTabs.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+import { NotificationFeed } from '../../common/api/feedsService';
+
+export interface FeedTabsProps {
+  userId: string;
+  isAdmin: boolean;
+  feeds?: {
+    [key: string]: NotificationFeed;
+  };
+}
+
+const FeedTabs: FC<FeedTabsProps> = ({ userId, isAdmin, feeds }) => {
+  if (!feeds) {
+    return <></>;
+  }
+  return (
+    <>
+      {Object.keys(feeds).map((feedId, idx) => {
+        return <FeedTab feedId={feedId} feed={feeds[feedId]} key={idx} />;
+      })}
+    </>
+  );
+};
+
+const FeedTab: FC<{ feedId: string; feed: NotificationFeed }> = ({
+  feedId,
+  feed,
+}) => {
+  return <div>{feed.name}</div>;
+};
+
+export default FeedTabs;

--- a/src/features/feeds/Feeds.test.tsx
+++ b/src/features/feeds/Feeds.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter as Router } from 'react-router-dom';
+import { createTestStore } from '../../app/store';
+import Feeds from './Feeds';
+
+test('Feeds renders', async () => {
+  const store = createTestStore();
+  const { container } = render(
+    <Provider store={store}>
+      <Router>
+        <Feeds />
+      </Router>
+    </Provider>
+  );
+  expect(container).toBeTruthy();
+  expect(screen.getByText(/Feeds/, { exact: false })).toBeInTheDocument();
+  await waitFor(() => {
+    expect(store.getState().layout.pageTitle).toBe('Notification Feeds');
+  });
+});

--- a/src/features/feeds/Feeds.tsx
+++ b/src/features/feeds/Feeds.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+import { usePageTitle } from '../layout/layoutSlice';
+import FeedTabs from './FeedTabs';
+import { getFeeds } from '../../common/api/feedsService';
+
+const feedsPath = '/feeds';
+
+const Feeds: FC = () => {
+  usePageTitle('Notification Feeds');
+  const { data: feedsData } = getFeeds.useQuery({});
+  return (
+    <>
+      <h1>Hello I am Feeds.</h1>
+      <FeedTabs userId="foo" isAdmin={false} feeds={feedsData}></FeedTabs>
+    </>
+  );
+};
+
+export { feedsPath };
+export default Feeds;

--- a/src/features/layout/LeftNavBar.tsx
+++ b/src/features/layout/LeftNavBar.tsx
@@ -44,6 +44,12 @@ const LeftNavBar: FC = () => {
           badge={feeds?.unseen.global}
         />
         <NavItem
+          path="/feeds"
+          desc="Feeds"
+          icon={faBullhorn}
+          badge={'not yet'}
+        />
+        <NavItem
           path="/collections"
           desc="Collections"
           icon={faLayerGroup}


### PR DESCRIPTION
Just an initial test to try to scope out what getting Feeds would look like ported over to Europa.

It's a pretty simple page, so it shouldn't take too long. These changes took ~1.5 hours (including about a half hour shuffle of npm and local system updates to get the build to work).

Based on this first pass, I'd estimate about a week full time to port over the Feeds functionality. Maybe more for testing.

Interfaces, etc., all based on documentation here: https://github.com/kbase/feeds