### PR TITLE
Add media data to biolog heatmap tooltips.

### DIFF
--- a/src/common/api/collectionsApi.ts
+++ b/src/common/api/collectionsApi.ts
@@ -97,6 +97,7 @@ export interface HeatMapCell {
   cell_id: string;
   col_id: HeatMapColumn['col_id'];
   val: number | boolean;
+  meta?: Record<string, string>;
 }
 
 export interface HeatMapRow {

--- a/src/features/collections/data_products/Biolog.tsx
+++ b/src/features/collections/data_products/Biolog.tsx
@@ -74,6 +74,8 @@ export const Biolog: FC<{
           Col: {column.columnDef.header}
           <br />
           Val: {`${cell.val}`}
+          <br />
+          Media: {`${cell.meta?.growth_media}`}
           <>
             {data.values.map(({ id, val }) => (
               <div key={id}>{`- ${id}:${val}`}</div>

--- a/src/features/collections/data_products/HeatMap.tsx
+++ b/src/features/collections/data_products/HeatMap.tsx
@@ -159,6 +159,7 @@ const getPlotlyFromTanstack = ({
           cell_id,
           col_id,
           val,
+          meta: row.original.meta,
         };
       });
       const cellLabels: (React.ReactElement | string | null)[] = [];
@@ -171,6 +172,7 @@ const getPlotlyFromTanstack = ({
           cell_id,
           col_id,
           val,
+          meta: row.original.meta,
         };
         const hmr: HeatMapRow = {
           match: false,


### PR DESCRIPTION
- [x] The Biolog data product shows the media data from the row metadata in cell tooltips.