### PR TITLE
RE2022-254: Modify heatmap tooltips

### DIFF
--- a/src/common/components/Button.module.scss
+++ b/src/common/components/Button.module.scss
@@ -51,7 +51,7 @@
       color: use-color("white");
     }
 
-    @if (use-color($state + "-dark")) {
+    @if (map-has-key($palette, $state + "-dark")) {
       &:hover {
         background-color: use-color($state + "-dark");
         color: use-color("white");
@@ -59,7 +59,7 @@
       }
     }
 
-    @if (use-color($state + "-dark")) {
+    @if (map-has-key($palette, $state + "-darker")) {
       &:focus {
         background-color: use-color($state + "-darker");
         color: use-color("white");
@@ -72,7 +72,7 @@
     color: use-color($state);
     font-weight: bold;
 
-    @if (use-color($state + "-dark")) {
+    @if (map-has-key($palette, $state + "-dark")) {
       &:hover {
         background-color: use-color("light-gray");
         color: use-color($state + "-dark");
@@ -80,7 +80,7 @@
       }
     }
 
-    @if (use-color($state + "-dark")) {
+    @if (map-has-key($palette, $state + "-darker")) {
       &:focus {
         color: use-color($state + "-darker");
       }

--- a/src/features/collections/data_products/Biolog.tsx
+++ b/src/features/collections/data_products/Biolog.tsx
@@ -68,23 +68,41 @@ export const Biolog: FC<{
     } else {
       return (
         <>
-          Type: {column.columnDef.meta?.type}
-          <hr />
-          Row: (
-          <DataViewLink identifier={row.kbase_id}>
-            {row.kbase_id}
-          </DataViewLink>) {row.kbase_display_name}
-          <br />
-          Col: {column.columnDef.header}
-          <br />
-          Val: {`${cell.val}`}
-          <br />
-          Media: {`${cell.meta?.growth_media}`}
-          <>
+          <table>
+            <tr>
+              <th>KBase ID</th>
+              <td>
+                <DataViewLink identifier={row.kbase_id}>
+                  {row.kbase_id}
+                </DataViewLink>
+                ) {row.kbase_display_name}
+              </td>
+            </tr>
+            <tr>
+              <th>Treatment</th>
+              <td>{`${column.columnDef.header}`}</td>
+            </tr>
+            <tr>
+              <td colSpan={2}>
+                <hr />
+              </td>
+            </tr>
+            <tr>
+              <th>Type</th>
+              <td>{column.columnDef.meta?.type}</td>
+            </tr>
+            <tr>
+              <th>Value</th>
+              <td> {`${cell.val}`}</td>
+            </tr>
+            <tr>
+              <th>Media</th>
+              <td>{cell.meta?.growth_media}</td>
+            </tr>
             {data.values.map(({ id, val }) => (
               <div key={id}>{`- ${id}:${val}`}</div>
             ))}
-          </>
+          </table>
         </>
       );
     }

--- a/src/features/collections/data_products/Biolog.tsx
+++ b/src/features/collections/data_products/Biolog.tsx
@@ -93,15 +93,12 @@ export const Biolog: FC<{
             </tr>
             <tr>
               <th>Value</th>
-              <td> {`${cell.val}`}</td>
+              <td> {cell.val}</td>
             </tr>
             <tr>
               <th>Media</th>
               <td>{cell.meta?.growth_media}</td>
             </tr>
-            {data.values.map(({ id, val }) => (
-              <div key={id}>{`- ${id}:${val}`}</div>
-            ))}
           </table>
         </>
       );

--- a/src/features/collections/data_products/HeatMap.module.scss
+++ b/src/features/collections/data_products/HeatMap.module.scss
@@ -100,6 +100,7 @@ See the mouseout handler in the <HeatMap /> component.
   color: use-color("white");
   font-size: 0.667rem;
   font-weight: bold;
+  max-width: 250px;
   padding: 4px 8px;
   position: fixed;
   z-index: 1;
@@ -111,6 +112,19 @@ See the mouseout handler in the <HeatMap /> component.
 
 .tooltip a:visited {
   color: use-color("accent-cool");
+}
+
+.tooltip th {
+  min-width: 4rem;
+  text-align: left;
+  vertical-align: top;
+  word-break: normal;
+  word-wrap: break-word;
+}
+
+.tooltip td {
+  text-align: left;
+  word-break: break-all;
 }
 
 .trait-names {

--- a/src/features/collections/data_products/Microtrait.tsx
+++ b/src/features/collections/data_products/Microtrait.tsx
@@ -70,22 +70,60 @@ export const Microtrait: FC<{
     } else {
       return (
         <>
-          Type: {column.columnDef.meta?.type}
-          <hr />
-          Row: (
-          <DataViewLink identifier={getUPAFromEncoded(row.kbase_id)}>
-            {getUPAFromEncoded(row.kbase_id)}
-          </DataViewLink>
-          ) {row.kbase_display_name}
-          <br />
-          Col: {column.columnDef.header}
-          <br />
-          Val: {`${cell.val}`}
-          <>
-            {data.values.map(({ id, val }) => (
-              <div key={id}>{`- ${id}:${val}`}</div>
-            ))}
-          </>
+          <table>
+            <tr>
+              <th>KBase ID</th>
+              <td>
+                (
+                <DataViewLink identifier={getUPAFromEncoded(row.kbase_id)}>
+                  {getUPAFromEncoded(row.kbase_id)}
+                </DataViewLink>
+                ) {row.kbase_display_name}
+              </td>
+            </tr>
+            <tr>
+              <th>Trait</th>
+              <td>{`${column.columnDef.header}`}</td>
+            </tr>
+            <tr>
+              <td colSpan={2}>
+                <hr />
+              </td>
+            </tr>
+            <tr>
+              <th>Type</th>
+              <td>{column.columnDef.meta?.type}</td>
+            </tr>
+            <tr>
+              <th>Value</th>
+              <td> {`${cell.val}`}</td>
+            </tr>
+            {data.values.length > 0 ? (
+              <>
+                <tr>
+                  <td colSpan={2}>
+                    <hr />
+                  </td>
+                </tr>
+                <tr>
+                  <th>Genes Detected</th>
+                  <th>
+                    <abbr title="Trusted Cutoff">TC</abbr> value
+                  </th>
+                </tr>
+                <>
+                  {data.values.map(({ id, val }) => (
+                    <tr key={id}>
+                      <td>{id}</td>
+                      <td>{val}</td>
+                    </tr>
+                  ))}
+                </>
+              </>
+            ) : (
+              <></>
+            )}
+          </table>
         </>
       );
     }


### PR DESCRIPTION
Tooltips to show when hovering over a cell in the heatmaps. Tooltip design could be reused in other areas of the app.

- [x] Use meaningful labels for Row and Col, perhaps KBase ID and Trait
- [x] Use meaningful labels for extra fields (e.g. cysl and growth_media)
- [ ] ~~Use the LabelValueTable component so the values are left-aligned together~~
- [x] Use max width of ~250px and allow text wrapping
- [x] Add a separator between the row/col fields and the other fields
- [x] Match attached mockup as best as possible