### PR TITLE
URO-211 part A - support for kbase service mocking

### DIFF
--- a/src/common/api/index.ts
+++ b/src/common/api/index.ts
@@ -1,10 +1,19 @@
-import { kbaseBaseQuery } from './utils/kbaseBaseQuery';
 import { createApi } from '@reduxjs/toolkit/query/react';
+import { kbaseBaseQuery } from './utils/kbaseBaseQuery';
 
-const baseUrl =
-  process.env.NODE_ENV === 'development'
-    ? 'http://localhost:3000/'
-    : `https://${process.env.REACT_APP_KBASE_DOMAIN}`;
+export const baseUrl = (() => {
+  const nodeEnv = process.env.NODE_ENV;
+  if (nodeEnv === 'development') {
+    return 'http://localhost:3000/';
+  } else if (nodeEnv === 'test') {
+    // This prevents API calls from attempting to talk to live servers on CI.
+    // Tests which utilize actual api calls should either mock the endpoint on
+    // localhost, or mock the api itself.
+    return 'http://localhost/';
+  } else {
+    return `https://${process.env.REACT_APP_KBASE_DOMAIN}/`;
+  }
+})();
 
 export const baseApi = createApi({
   reducerPath: 'combinedApi',

--- a/src/features/icons/AppCellIcon.test.tsx
+++ b/src/features/icons/AppCellIcon.test.tsx
@@ -1,30 +1,47 @@
-import AppCellIcon from './AppCellIcon';
-import { createTestStore } from '../../app/store';
-import { Provider } from 'react-redux';
 import { render, waitFor } from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import { FetchMock } from 'jest-fetch-mock/types';
+import { Provider } from 'react-redux';
+import { createTestStore } from '../../app/store';
+import { makeKBaseServices } from '../../test/kbaseServiceMock';
+import AppCellIcon from './AppCellIcon';
 import { AppTag } from './iconSlice';
 
-test('AppCellIcon renders initial loading icon', () => {
-  const { container } = render(
-    <Provider store={createTestStore()}>
-      <AppCellIcon appId="SomeModule.someApp" appTag={AppTag.release} />
-    </Provider>
-  );
-  expect(container.querySelector('svg[data-icon="spinner"]')).not.toBeNull();
-});
+describe('The AppCellIcon', () => {
+  let mockService: FetchMock;
 
-test('AppCellIcon renders an icon after the callback finishes', async () => {
-  const { container } = render(
-    <Provider store={createTestStore()}>
-      <AppCellIcon appId="SomeModule.someApp" appTag={AppTag.beta} />
-    </Provider>
-  );
-  await waitFor(() => {
-    expect(
-      container.querySelector('svg[data-icon="spinner"]')
-    ).not.toBeInTheDocument();
-    expect(
-      container.querySelector('svg[data-icon="cube"]')
-    ).toBeInTheDocument();
+  beforeEach(() => {
+    fetchMock.enableMocks();
+    mockService = makeKBaseServices();
+  });
+
+  afterEach(() => {
+    mockService.mockClear();
+    fetchMock.disableMocks();
+  });
+
+  test('renders initial loading icon', () => {
+    const { container } = render(
+      <Provider store={createTestStore()}>
+        <AppCellIcon appId="SomeModule.someApp" appTag={AppTag.release} />
+      </Provider>
+    );
+    expect(container.querySelector('svg[data-icon="spinner"]')).not.toBeNull();
+  });
+
+  test('renders an icon after the callback finishes', async () => {
+    const { container } = render(
+      <Provider store={createTestStore()}>
+        <AppCellIcon appId="SomeModule.someApp" appTag={AppTag.beta} />
+      </Provider>
+    );
+    await waitFor(() => {
+      expect(
+        container.querySelector('svg[data-icon="spinner"]')
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('svg[data-icon="cube"]')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/features/profile/profileSlice.test.tsx
+++ b/src/features/profile/profileSlice.test.tsx
@@ -1,21 +1,31 @@
-// Start a new test file for profileSlice specifically.
 import { render, waitFor } from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import { FetchMock } from 'jest-fetch-mock/types';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Provider } from 'react-redux';
-
 import { createTestStore } from '../../app/store';
-
+import { makeKBaseServices } from '../../test/kbaseServiceMock';
 import { useLoggedInProfileUser } from './profileSlice';
 
 let testStore = createTestStore({});
+
 describe('useLoggedInProfileUser', () => {
+  let mockService: FetchMock;
+
   beforeEach(() => {
     testStore = createTestStore({});
+    fetchMock.enableMocks();
+    mockService = makeKBaseServices();
   });
 
-  test('useLoggedInProfileUser sets loggedInProfile on success with valid username', async () => {
+  afterEach(() => {
+    mockService.mockClear();
+    fetchMock.disableMocks();
+  });
+
+  test('sets loggedInProfile on success with valid username', async () => {
     const Component = () => {
-      useLoggedInProfileUser('dlyon');
+      useLoggedInProfileUser('kbaseuitest');
       return <></>;
     };
     render(
@@ -25,18 +35,18 @@ describe('useLoggedInProfileUser', () => {
     );
     await waitFor(() =>
       expect(testStore.getState().profile.loggedInProfile?.user.username).toBe(
-        'dlyon'
+        'kbaseuitest'
       )
     );
   });
 
-  test('useLoggedInProfileUser throws error when called with invalid username', async () => {
+  test('throws error when called with invalid username', async () => {
     const onErr = jest.fn();
     const consoleError = jest.spyOn(console, 'error');
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     consoleError.mockImplementation(() => {});
     const Component = () => {
-      useLoggedInProfileUser('!!!Iamnotause');
+      useLoggedInProfileUser('not_a_user');
       return <></>;
     };
     render(

--- a/src/test/data/narrative_method_store.ts
+++ b/src/test/data/narrative_method_store.ts
@@ -1,0 +1,55 @@
+/**
+ * Test data from the NarrativeMethodStore service.
+ *
+ * All data is from live calls to the CI instance of NMS in June 2024.
+ *
+ * All data represents just the data needed for testing. For instance, it is
+ * unwrapped from the rpc structure and the results array.
+ */
+
+/**
+ * Result of a call to the  "NarrativeMethodStore.status" method
+ * 
+ * curl -X POST https://ci.kbase.us/services/narrative_method_store/rpc \
+    -d '{
+  "version": "1.1",
+  "id": "123",
+  "method": "NarrativeMethodStore.status",
+  "params": []
+  }'
+ */
+export const STATUS_1 = {
+  git_spec_url: 'https://github.com/kbase/narrative_method_specs_ci',
+  git_spec_branch: 'master',
+  git_spec_commit:
+    'commit 042b36d193054ccb42f7e3a89d35c2a9989ecceb\nMerge: 7c58bbd 952d3d4\nAuthor: Bill Riehl <briehl@users.noreply.github.com>\nDate:   Wed Nov 10 12:41:27 2021 -0800\n\n    Merge pull request #110 from qzzhang/master\n    \n    Added the KBaseStructure structure types\n',
+  update_interval: '5',
+};
+
+/**
+ * An example app "brief info". The data represents just the brief info for the
+ * single app requested, rather than the array returned in the actual result.
+ * 
+ * curl -X POST https://ci.kbase.us/services/narrative_method_store/rpc \
+    -d '{
+  "version": "1.1",
+  "id": "123",
+  "method": "NarrativeMethodStore.get_method_brief_info",
+  "params": [{"ids": ["NarrativeViewers/view_assembly"]}]
+  }'
+ */
+export const VIEW_ASSEMBLY_BRIEF_INFO_1 = {
+  id: 'NarrativeViewers/view_assembly',
+  module_name: 'NarrativeViewers',
+  git_commit_hash: '0851ff66474b615dcf447499d133885a09adc862',
+  name: 'View Assembly',
+  ver: '1.0.8',
+  subtitle: 'View and explore an Assembly object in your workspace. [5]',
+  tooltip: 'View and explore an Assembly in your workspace. [5]',
+  categories: ['viewers'],
+  authors: [],
+  input_types: ['KBaseGenomeAnnotations.Assembly', 'KBaseGenomes.ContigSet'],
+  output_types: [],
+  app_type: 'viewer',
+  namespace: 'NarrativeViewers',
+};

--- a/src/test/data/user_profile.ts
+++ b/src/test/data/user_profile.ts
@@ -1,0 +1,126 @@
+/**
+ * The user profile for the CI test user "kbaseuitest". 
+ * 
+ * This is the result of a call to the user profile service's "UserProfile.get_user_profile" method.
+ * curl -X POST https://ci.kbase.us/services/user_profile/rpc \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{
+    "version": "1.1",
+    "id": "123",
+    "method": "UserProfile.get_user_profile",
+    "params": [["eapearson"]]
+  }'
+ */
+
+export const KBASEUITEST_PROFILE = {
+  user: {
+    username: 'kbaseuitest',
+    realname: 'KBase UI Test User',
+  },
+  profile: {
+    metadata: {
+      createdBy: 'userprofile_ui_service',
+      created: '2020-01-06T21:48:12.352Z',
+    },
+    preferences: {},
+    userdata: {
+      organization: '',
+      department: '',
+      affiliations: [
+        {
+          title: 'tester',
+          organization: 'kbase / lbnl',
+          started: 2020,
+          ended: 2020,
+        },
+      ],
+      city: '',
+      state: 'California',
+      postalCode: '',
+      country: '',
+      researchStatement:
+        "Test user account for ui integration tests.\n\nPlease don't modify the profile.\n\nThis **can** be markdown, but who would know?",
+      gravatarDefault: 'monsterid',
+      avatarOption: 'gravatar',
+      researchInterests: [
+        'Comparative Genomics',
+        'Genome Annotation',
+        'Metabolic Modeling',
+        'Read Processing',
+        'Sequence Analysis',
+      ],
+      researchInterestsOther: null,
+      jobTitleOther: 'My job',
+      jobTitle: 'Other',
+      fundingSource: '',
+    },
+    synced: {
+      gravatarHash: 'b4d95f8595104614355e6ee9c4c03e3f',
+    },
+    plugins: {
+      'data-search': {
+        settings: {
+          history: {
+            search: {
+              history: [
+                'coli',
+                'abcde12345',
+                'Abiotrophi',
+                'sphaeroides',
+                'orientalis',
+                'Abiotrophia',
+                'marinus',
+                'Prochlorococcus marinus str. GP2',
+                'query-compost_hq_bins_blastp_output.Seq',
+                'SequenceSet',
+              ],
+              time: {
+                $numberLong: '1656371918191',
+              },
+            },
+          },
+        },
+      },
+      'jgi-search': {
+        settings: {
+          history: {
+            search: {
+              history: ['coli', 'blahblah', 'Colin'],
+              time: {
+                $numberLong: '1658255057551',
+              },
+            },
+          },
+          jgiDataTerms: {
+            agreed: true,
+            time: {
+              $numberLong: '1580251462454',
+            },
+          },
+        },
+      },
+      'public-search': {
+        settings: {
+          history: {
+            history: [
+              'prochlorococcus',
+              'coli',
+              'orientalis',
+              'Acetobacter orientalis',
+              'prochlorococcus marinus',
+              'AnnotatedGenomeAssembly',
+              'prochlorococcus marnius',
+              'Prochlorococcus marinus str. GP2',
+              'AnnotatedMetagenomeAssembly',
+              'prochlorococcus unconfirmed',
+            ],
+            time: {
+              $numberLong: '1656372755178',
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/test/jsonrpc11.ts
+++ b/src/test/jsonrpc11.ts
@@ -1,0 +1,106 @@
+/**
+ * JSON-RPC/1.1 support for testing.
+ *
+ * Constrainted by KBase interpretation and usage of JSON-RPC/1.1.
+ *
+ * Only used in a few tests, so may need tweaking in the future to handle
+ * additional use cases.
+ */
+
+import { MockResponseInit } from 'jest-fetch-mock/types';
+
+export type JSONRPC11Id = string;
+
+export type JSONRPC11Params = Array<unknown>;
+
+// The entire JSON RPC request object
+export interface JSONRPC11Request {
+  version: '1.1';
+  method: string;
+  id?: JSONRPC11Id;
+  params?: JSONRPC11Params;
+}
+
+export interface JSONRPC11Object {
+  [key: string]: JSONRPC11Result;
+}
+
+export type JSONRPC11Result =
+  | string
+  | number
+  | null
+  | JSONRPC11Object
+  | Array<JSONRPC11Result>;
+
+// Response object
+
+export interface JSONRPC11BaseResponse {
+  version: '1.1';
+  id?: JSONRPC11Id;
+}
+
+export interface JSONRPC11ResultResponse extends JSONRPC11BaseResponse {
+  result: JSONRPC11Result;
+}
+
+export interface JSONRPC11ErrorResponse extends JSONRPC11BaseResponse {
+  error: JSONRPC11Error;
+}
+
+export type JSONRPC11Response =
+  | JSONRPC11ResultResponse
+  | JSONRPC11ErrorResponse;
+
+export interface JSONRPC11Error {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+// These functions help us craft JSON-RPC 1.1 responses with minimal input.
+
+export function jsonrpc11_resultResponse(
+  id: string,
+  result: unknown
+): MockResponseInit {
+  return {
+    body: JSON.stringify({
+      version: '1.1',
+      id,
+      result,
+    }),
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+    },
+  };
+}
+
+export function jsonrpc11_response(
+  result: JSONRPC11Response
+): MockResponseInit {
+  return {
+    body: JSON.stringify(result),
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+    },
+  };
+}
+
+export function jsonrpc11_errorResponse(
+  id: string,
+  error: JSONRPC11Error
+): MockResponseInit {
+  return {
+    body: JSON.stringify({
+      version: '1.1',
+      id,
+      error,
+    }),
+    status: 500,
+    headers: {
+      'content-type': 'application/json',
+    },
+  };
+}

--- a/src/test/kbaseServiceMock.ts
+++ b/src/test/kbaseServiceMock.ts
@@ -1,0 +1,107 @@
+/**
+ * A testing http server for simulating KBase service endpoints.
+ *
+ * When testing components, apis, or other elements of Europa which depend upon contacting
+ * external resources via http, the recommended approach is to avoid mocking
+ * local code like api clients, but rather to provide an actual api endpoint.
+ *
+ * This implementation uses the "mirage" library, which intercepts fetch
+ * requests.
+ *
+ * One implication of this is that ALL fetch requests will be run against the
+ * mock server. Any tests which inadvertently rely upon contacting CI services
+ * will fail unless support is added herein.
+ *
+ * Note too that the host origin is 'http://localhost'. See
+ * `src/common/api/index.ts` which defines baseUrl for the test environment.
+ */
+import { MockResponseInit } from 'jest-fetch-mock/types';
+import {
+  STATUS_1,
+  VIEW_ASSEMBLY_BRIEF_INFO_1,
+} from './data/narrative_method_store';
+import { KBASEUITEST_PROFILE } from './data/user_profile';
+import { jsonrpc11_resultResponse } from './jsonrpc11';
+
+/**
+ * Creates response for fetch mock supplied by jest-fetch-mock.
+ *
+ * Most data used for responses is located in the "data" directory.
+ *
+ */
+export function makeKBaseServices() {
+  return fetchMock.mockResponse(
+    async (request): Promise<MockResponseInit | string> => {
+      const { pathname } = new URL(request.url);
+      // put a little delay in here so that we have a better
+      // chance of catching temporary conditions, like loading.
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(null);
+        }, 300);
+      });
+      switch (pathname) {
+        case '/services/user_profile/rpc': {
+          if (request.method !== 'POST') {
+            return '';
+          }
+          const body = await request.json();
+          const id = body['id'];
+          const method = body['method'];
+          const params = body['params'];
+          switch (method) {
+            case 'UserProfile.get_user_profile': {
+              const users = params[0];
+              if (users.length === 0) {
+                return jsonrpc11_resultResponse(id, [[]]);
+              }
+              switch (users[0]) {
+                case 'not_a_user':
+                  // When a user profile is not found;
+                  return jsonrpc11_resultResponse(id, [[null]]);
+                case 'kbaseuitest':
+                  return jsonrpc11_resultResponse(id, [[KBASEUITEST_PROFILE]]);
+                default:
+                  throw new Error('case not handled');
+              }
+            }
+
+            default:
+              throw new Error('case not handled');
+          }
+        }
+        case '/services/narrative_method_store': {
+          if (request.method !== 'POST') {
+            return '';
+          }
+          const body = await request.json();
+          const id = body['id'];
+          const method = body['method'];
+          const params = body['params'];
+          switch (method) {
+            case 'NarrativeMethodStore.get_method_brief_info': {
+              const ids = params['ids'];
+
+              switch (ids[0]) {
+                case 'SomeModule.someApp':
+                  return jsonrpc11_resultResponse(id, [
+                    [VIEW_ASSEMBLY_BRIEF_INFO_1],
+                  ]);
+                default:
+                  throw new Error('case not handled');
+              }
+            }
+            case 'NarrativeMethodStore.status': {
+              return jsonrpc11_resultResponse(id, [[STATUS_1]]);
+            }
+
+            default:
+              throw new Error('case not handled');
+          }
+        }
+        default:
+          throw new Error('case not handled');
+      }
+    }
+  );
+}

--- a/src/test/settings.ts
+++ b/src/test/settings.ts
@@ -1,0 +1,10 @@
+/**
+ * Various settings to be used in common between tests that don't have another home.
+ */
+
+// We can have a short default timeout, as tests should be running against a
+// local server with very low latency.
+//
+// Of course if you are testing timeout errors, you should ignore this and use
+// whatever values are required to trigger whatever conditions are needed.
+export const API_CALL_TIMEOUT = 1000;


### PR DESCRIPTION
This PR extracts changes form the rest of URO-211, which adds support for creating ORCID Links (but deleting, managing, or user profile integration). 

The tests for those changes requires extensive mocking of orcidlink service endpoints. It was then that I discovered that the baseUrl was not specifically configured for the test environment. Rather, without this configuration it defaulted to the production urls - which in turn default to CI. Two sets of tests were actively contacting CI services in their tests and immediately broken when I added support for the test environment baseUrl to orient to http://localhost.

So this set of changes includes:
- setting baseUrl to http://localhost for the node test enviromnet
- improving support for KBase JSON-RPC 1.1 service mocking
- updating two sets of tests to utilize those mocks, rather than contacting CI directly

These changes pave the way for the rest of URO-211, and reduce the # of changes in that future PR.