### PR TITLE
Add new Account layout

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -29,6 +29,7 @@ import ORCIDLinkFeature from '../features/orcidlink';
 import { LogIn } from '../features/login/LogIn';
 import { SignUp } from '../features/signup/SignUp';
 import ORCIDLinkCreateLink from '../features/orcidlink/CreateLink';
+import { Account } from '../features/account/Account';
 
 export const LOGIN_ROUTE = '/legacy/login';
 export const ROOT_REDIRECT_ROUTE = '/narratives';
@@ -58,6 +59,9 @@ const Routes: FC = () => {
 
       {/* Sign Up */}
       <Route path="/signup" element={<SignUp />} />
+
+      {/* Account */}
+      <Route path="/account" element={<Authed element={<Account />} />} />
 
       {/* Navigator */}
       <Route

--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -30,6 +30,10 @@ import { LogIn } from '../features/login/LogIn';
 import { SignUp } from '../features/signup/SignUp';
 import ORCIDLinkCreateLink from '../features/orcidlink/CreateLink';
 import { Account } from '../features/account/Account';
+import { AccountInfo } from '../features/account/AccountInfo';
+import { LinkedProviders } from '../features/account/LinkedProviders';
+import { LogInSessions } from '../features/account/LogInSessions';
+import { UseAgreements } from '../features/account/UseAgreements';
 
 export const LOGIN_ROUTE = '/legacy/login';
 export const ROOT_REDIRECT_ROUTE = '/narratives';
@@ -61,7 +65,22 @@ const Routes: FC = () => {
       <Route path="/signup" element={<SignUp />} />
 
       {/* Account */}
-      <Route path="/account" element={<Authed element={<Account />} />} />
+      <Route path="/account" element={<Authed element={<Account />} />}>
+        <Route index element={<Authed element={<AccountInfo />} />} />
+        <Route path="info" element={<Authed element={<AccountInfo />} />} />
+        <Route
+          path="providers"
+          element={<Authed element={<LinkedProviders />} />}
+        />
+        <Route
+          path="sessions"
+          element={<Authed element={<LogInSessions />} />}
+        />
+        <Route
+          path="use-agreements"
+          element={<Authed element={<UseAgreements />} />}
+        />
+      </Route>
 
       {/* Navigator */}
       <Route

--- a/src/features/account/Account.module.scss
+++ b/src/features/account/Account.module.scss
@@ -1,3 +1,7 @@
+/* stylelint-disable selector-class-pattern */
+
+@import "../../common/colors";
+
 .sso-logo {
   height: 2.5rem;
   width: auto;
@@ -6,5 +10,33 @@
 .provider-link-panel {
   margin: auto;
   max-width: 500px;
+  padding: 1rem;
+}
+
+.separator {
+  background-color: use-color("base-lighter");
+  height: 1px;
+}
+
+.policy-card {
+  border: 2px solid #fff;
+  cursor: pointer;
+  
+  &:global(.MuiCard-root) {
+    transition: 0.25s;
+  }
+
+  &:hover {
+    background-color: use-color("light-gray");
+    border-color: use-color("light-gray");
+  }
+
+  &.selected-card {
+    background-color: use-color("primary-lightest");
+    border-color: use-color("primary");
+  }
+}
+
+.policy-content {
   padding: 1rem;
 }

--- a/src/features/account/Account.module.scss
+++ b/src/features/account/Account.module.scss
@@ -1,0 +1,10 @@
+.sso-logo {
+  height: 2.5rem;
+  width: auto;
+}
+
+.provider-link-panel {
+  margin: auto;
+  max-width: 500px;
+  padding: 1rem;
+}

--- a/src/features/account/Account.tsx
+++ b/src/features/account/Account.tsx
@@ -3,6 +3,7 @@ import { FC, useEffect, useState } from 'react';
 import { AccountInfo } from './AccountInfo';
 import { LinkedProviders } from './LinkedProviders';
 import { LogInSessions } from './LogInSessions';
+import { UseAgreements } from './UseAgreements';
 
 /**
  * Main Account page with four subpages represented as tabs.
@@ -51,6 +52,9 @@ export const Account: FC = () => {
         </CustomTabPanel>
         <CustomTabPanel value={activeTab} index={2} name="logins">
           <LogInSessions />
+        </CustomTabPanel>
+        <CustomTabPanel value={activeTab} index={3} name="use-agreements">
+          <UseAgreements />
         </CustomTabPanel>
       </Stack>
     </Container>

--- a/src/features/account/Account.tsx
+++ b/src/features/account/Account.tsx
@@ -1,0 +1,84 @@
+import { Container, Stack, Tab, Tabs } from '@mui/material';
+import { FC, useEffect, useState } from 'react';
+import { AccountInfo } from './AccountInfo';
+
+/**
+ * Main Account page with four subpages represented as tabs.
+ */
+export const Account: FC = () => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setActiveTab(newValue);
+  };
+
+  useEffect(() => {
+    document.querySelector('main')?.scrollTo(0, 0);
+  }, [activeTab]);
+
+  return (
+    <Container maxWidth="lg">
+      <Stack spacing={4}>
+        <Tabs value={activeTab} onChange={handleChange}>
+          <Tab
+            label="Account"
+            id="account-tab"
+            aria-controls="account-tabpanel"
+          />
+          <Tab
+            label="Linked Providers"
+            id="providers-tab"
+            aria-controls="providers-tabpanel"
+          />
+          <Tab
+            label="Log Ins"
+            id="logins-tab"
+            aria-controls="logins-tabpanel"
+          />
+          <Tab
+            label="Use Agreements"
+            id="use-agreements-tab"
+            aria-controls="use-agreements-tabpanel"
+          />
+        </Tabs>
+        <CustomTabPanel value={activeTab} index={0} name="account">
+          <AccountInfo />
+        </CustomTabPanel>
+        <CustomTabPanel value={activeTab} index={1} name="providers">
+          Providers info
+        </CustomTabPanel>
+      </Stack>
+    </Container>
+  );
+};
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+  name: string;
+}
+
+/**
+ * Tab panel wrapper that conditionally displays tab content
+ * depending on the active tab.
+ */
+const CustomTabPanel: FC<TabPanelProps> = ({
+  value,
+  index,
+  name,
+  children,
+  ...rest
+}) => {
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`${name}-tabpanel`}
+      aria-labelledby={`${name}-tab`}
+      {...rest}
+    >
+      {value === index && children}
+    </div>
+  );
+};

--- a/src/features/account/Account.tsx
+++ b/src/features/account/Account.tsx
@@ -1,15 +1,27 @@
 import { Container, Stack, Tab, Tabs } from '@mui/material';
 import { FC, useEffect, useState } from 'react';
-import { AccountInfo } from './AccountInfo';
-import { LinkedProviders } from './LinkedProviders';
-import { LogInSessions } from './LogInSessions';
-import { UseAgreements } from './UseAgreements';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 /**
  * Main Account page with four subpages represented as tabs.
  */
 export const Account: FC = () => {
-  const [activeTab, setActiveTab] = useState(0);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [activeTab, setActiveTab] = useState(() => {
+    switch (location.pathname) {
+      case '/account/info':
+        return 0;
+      case '/account/providers':
+        return 1;
+      case '/account/logins':
+        return 2;
+      case '/account/use-agreements':
+        return 3;
+      default:
+        return 0;
+    }
+  });
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setActiveTab(newValue);
@@ -24,70 +36,36 @@ export const Account: FC = () => {
       <Stack spacing={4}>
         <Tabs value={activeTab} onChange={handleChange}>
           <Tab
+            component="a"
             label="Account"
             id="account-tab"
             aria-controls="account-tabpanel"
+            onClick={() => navigate('info')}
           />
           <Tab
+            component="a"
             label="Linked Providers"
             id="providers-tab"
             aria-controls="providers-tabpanel"
+            onClick={() => navigate('providers')}
           />
           <Tab
+            component="a"
             label="Log In Sessions"
-            id="logins-tab"
-            aria-controls="logins-tabpanel"
+            id="sessions-tab"
+            aria-controls="sessions-tabpanel"
+            onClick={() => navigate('sessions')}
           />
           <Tab
+            component="a"
             label="Use Agreements"
             id="use-agreements-tab"
             aria-controls="use-agreements-tabpanel"
+            onClick={() => navigate('use-agreements')}
           />
         </Tabs>
-        <CustomTabPanel value={activeTab} index={0} name="account">
-          <AccountInfo />
-        </CustomTabPanel>
-        <CustomTabPanel value={activeTab} index={1} name="providers">
-          <LinkedProviders />
-        </CustomTabPanel>
-        <CustomTabPanel value={activeTab} index={2} name="logins">
-          <LogInSessions />
-        </CustomTabPanel>
-        <CustomTabPanel value={activeTab} index={3} name="use-agreements">
-          <UseAgreements />
-        </CustomTabPanel>
+        <Outlet />
       </Stack>
     </Container>
-  );
-};
-
-interface TabPanelProps {
-  children?: React.ReactNode;
-  index: number;
-  value: number;
-  name: string;
-}
-
-/**
- * Tab panel wrapper that conditionally displays tab content
- * depending on the active tab.
- */
-const CustomTabPanel: FC<TabPanelProps> = ({
-  value,
-  index,
-  name,
-  children,
-  ...rest
-}) => {
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`${name}-tabpanel`}
-      aria-labelledby={`${name}-tab`}
-      {...rest}
-    >
-      {value === index && children}
-    </div>
   );
 };

--- a/src/features/account/Account.tsx
+++ b/src/features/account/Account.tsx
@@ -2,6 +2,7 @@ import { Container, Stack, Tab, Tabs } from '@mui/material';
 import { FC, useEffect, useState } from 'react';
 import { AccountInfo } from './AccountInfo';
 import { LinkedProviders } from './LinkedProviders';
+import { LogInSessions } from './LogInSessions';
 
 /**
  * Main Account page with four subpages represented as tabs.
@@ -32,7 +33,7 @@ export const Account: FC = () => {
             aria-controls="providers-tabpanel"
           />
           <Tab
-            label="Log Ins"
+            label="Log In Sessions"
             id="logins-tab"
             aria-controls="logins-tabpanel"
           />
@@ -47,6 +48,9 @@ export const Account: FC = () => {
         </CustomTabPanel>
         <CustomTabPanel value={activeTab} index={1} name="providers">
           <LinkedProviders />
+        </CustomTabPanel>
+        <CustomTabPanel value={activeTab} index={2} name="logins">
+          <LogInSessions />
         </CustomTabPanel>
       </Stack>
     </Container>

--- a/src/features/account/Account.tsx
+++ b/src/features/account/Account.tsx
@@ -1,6 +1,7 @@
 import { Container, Stack, Tab, Tabs } from '@mui/material';
 import { FC, useEffect, useState } from 'react';
 import { AccountInfo } from './AccountInfo';
+import { LinkedProviders } from './LinkedProviders';
 
 /**
  * Main Account page with four subpages represented as tabs.
@@ -45,7 +46,7 @@ export const Account: FC = () => {
           <AccountInfo />
         </CustomTabPanel>
         <CustomTabPanel value={activeTab} index={1} name="providers">
-          Providers info
+          <LinkedProviders />
         </CustomTabPanel>
       </Stack>
     </Container>

--- a/src/features/account/AccountInfo.tsx
+++ b/src/features/account/AccountInfo.tsx
@@ -16,7 +16,12 @@ import { FC } from 'react';
  */
 export const AccountInfo: FC = () => {
   return (
-    <Stack spacing={4}>
+    <Stack
+      spacing={4}
+      role="tabpanel"
+      id="account-tabpanel"
+      aria-labelledby="account-tab"
+    >
       <Stack direction="row" justifyContent="space-between">
         <Typography variant="h2">Edit Account</Typography>
         <Tooltip

--- a/src/features/account/AccountInfo.tsx
+++ b/src/features/account/AccountInfo.tsx
@@ -1,0 +1,61 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { FC } from 'react';
+
+/**
+ * Content for the Account tab in the Account page
+ */
+export const AccountInfo: FC = () => {
+  return (
+    <Stack spacing={4}>
+      <Stack direction="row" justifyContent="space-between">
+        <Typography variant="h2">Edit Account</Typography>
+        <Tooltip title="You may view and edit edit your basic account information here. Changes saved will be immediately available.">
+          <Button startIcon={<FontAwesomeIcon icon={faInfoCircle} />}>
+            About this tab
+          </Button>
+        </Tooltip>
+      </Stack>
+      <Stack spacing={2}>
+        <FormControl>
+          <FormLabel htmlFor="username-input">Name</FormLabel>
+          <TextField
+            id="username-input"
+            helperText="Your real name, displayed to other KBase users"
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel htmlFor="email-input">Email</FormLabel>
+          <TextField
+            id="email-input"
+            helperText="KBase may use this email address to communicate important information about KBase or your account. KBase will not share your email address with anyone, and other KBase users will not be able to see it."
+          />
+        </FormControl>
+      </Stack>
+      <Typography variant="h2">Account Info</Typography>
+      <Stack spacing={2}>
+        <Stack>
+          <Typography fontWeight="bold">Username</Typography>
+          <Typography>coolkbasehuman</Typography>
+        </Stack>
+        <Stack>
+          <Typography fontWeight="bold">Account Created</Typography>
+          <Typography>Apr 19, 2023 at 9:32am</Typography>
+        </Stack>
+        <Stack>
+          <Typography fontWeight="bold">Last Sign In</Typography>
+          <Typography>3 days ago (Jul 9, 2024 at 9:05am)</Typography>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/features/account/AccountInfo.tsx
+++ b/src/features/account/AccountInfo.tsx
@@ -19,7 +19,14 @@ export const AccountInfo: FC = () => {
     <Stack spacing={4}>
       <Stack direction="row" justifyContent="space-between">
         <Typography variant="h2">Edit Account</Typography>
-        <Tooltip title="You may view and edit edit your basic account information here. Changes saved will be immediately available.">
+        <Tooltip
+          title={
+            <Typography variant="body2">
+              You may view and edit edit your basic account information here.
+              Changes saved will be immediately available.
+            </Typography>
+          }
+        >
           <Button startIcon={<FontAwesomeIcon icon={faInfoCircle} />}>
             About this tab
           </Button>

--- a/src/features/account/LinkedProviders.tsx
+++ b/src/features/account/LinkedProviders.tsx
@@ -1,0 +1,149 @@
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  Button,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { FC } from 'react';
+import globusLogo from '../../common/assets/globus.png';
+import googleLogo from '../../common/assets/google.webp';
+import orcidLogo from '../../common/assets/orcid.png';
+import classes from './Account.module.scss';
+
+/**
+ * Dummy data for the linked providers table.
+ * Can be deleted once table is linked to backend.
+ */
+const sampleProviders = [
+  {
+    provider: 'Google',
+    username: 'coolkbasehuman@lbl.gov',
+    linked: true,
+  },
+];
+
+/**
+ * Content for the Linked Providers tab in the Account page
+ */
+export const LinkedProviders: FC = () => {
+  const linkedProviders = sampleProviders;
+  return (
+    <Stack spacing={4}>
+      <Stack direction="row" justifyContent="space-between">
+        <Typography variant="h2">Currently Linked Providers</Typography>
+        <Tooltip
+          title={
+            <Stack spacing={1}>
+              <Typography variant="body2">
+                This tab provides access to all of the the external accounts
+                which you have set up sign in to your KBase account. You should
+                be able to recognize the account from the "Provider" and
+                "Username" columns.
+              </Typography>
+              <Typography variant="body2">
+                You may only link an external sign-in account to a single KBase
+                account. If you attempt to link an external sign-in account
+                which is already linked to another KBase account you will
+                receive an error message.
+              </Typography>
+              <Typography variant="body2">
+                You may unlink any linked sign-in account from your KBase
+                Account at any time.
+              </Typography>
+              <Typography variant="body2">
+                However, since you at present have just a single linked account,
+                you will not be able to unlink it. A KBase account must always
+                have at least one linked identity to ensure that it is
+                accessible. If you wish to unlink this account, you must first
+                link at least one additional sign-in account.
+              </Typography>
+            </Stack>
+          }
+        >
+          <Button startIcon={<FontAwesomeIcon icon={faInfoCircle} />}>
+            About this tab
+          </Button>
+        </Tooltip>
+      </Stack>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Provider</TableCell>
+            <TableCell>Username</TableCell>
+            <TableCell>Action</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {linkedProviders.map((provider, i) => (
+            <TableRow key={`${provider}-${i}`}>
+              <TableCell>{provider.provider}</TableCell>
+              <TableCell>{provider.username}</TableCell>
+              <TableCell>
+                <Button variant="contained" color="error">
+                  Unlink
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <Typography variant="h2">
+        Link an additional sign-in account to this KBase account
+      </Typography>
+      <Paper className={classes['provider-link-panel']} elevation={0}>
+        <Stack spacing={2}>
+          <Button
+            variant="outlined"
+            color="base"
+            size="large"
+            startIcon={
+              <img
+                src={orcidLogo}
+                alt="ORCID logo"
+                className={classes['sso-logo']}
+              />
+            }
+          >
+            Link with ORCID
+          </Button>
+          <Button
+            variant="outlined"
+            color="base"
+            size="large"
+            startIcon={
+              <img
+                src={googleLogo}
+                alt="Google logo"
+                className={classes['sso-logo']}
+              />
+            }
+          >
+            Link with Google
+          </Button>
+          <Button
+            variant="outlined"
+            color="base"
+            size="large"
+            startIcon={
+              <img
+                src={globusLogo}
+                alt="Globus logo"
+                className={classes['sso-logo']}
+              />
+            }
+          >
+            Link with Globus
+          </Button>
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+};

--- a/src/features/account/LinkedProviders.tsx
+++ b/src/features/account/LinkedProviders.tsx
@@ -36,7 +36,12 @@ const sampleProviders = [
 export const LinkedProviders: FC = () => {
   const linkedProviders = sampleProviders;
   return (
-    <Stack spacing={4}>
+    <Stack
+      spacing={4}
+      role="tabpanel"
+      id="providers-tabpanel"
+      aria-labelledby="providers-tab"
+    >
       <Stack direction="row" justifyContent="space-between">
         <Typography variant="h2">Currently Linked Providers</Typography>
         <Tooltip

--- a/src/features/account/LogInSessions.tsx
+++ b/src/features/account/LogInSessions.tsx
@@ -1,0 +1,124 @@
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  Button,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { FC } from 'react';
+
+/**
+ * Dummy data for the log in sessions table.
+ * Can be deleted once table is linked to backend.
+ */
+const sampleSessions = [
+  {
+    created: 'Jul 9, 2024 at 9:05am	',
+    expires: '10d 18h 42m	',
+    browser: 'Chrome 125.0.0.0	',
+    operatingSystem: 'Mac OS X 10.15.7	',
+    ipAddress: '192.184.174.53',
+  },
+];
+
+/**
+ * Content for the Log In Sessions tab in the Account page
+ */
+export const LogInSessions: FC = () => {
+  const currentSessions = sampleSessions;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const otherSessions: any[] = [];
+
+  return (
+    <Stack spacing={4}>
+      <Stack direction="row" justifyContent="space-between">
+        <Typography variant="h2">My Current Log In Sessions</Typography>
+        <Tooltip
+          title={
+            <Stack spacing={1}>
+              <Typography variant="body2">
+                A log in session is created when you log in to KBase. A log in
+                session is removed when you logout. However, if you do not
+                logout, your log in session will remain active for two weeks. At
+                the end of two weeks, the log in session will become invalid,
+                and you will need to log in again.
+              </Typography>
+            </Stack>
+          }
+        >
+          <Button startIcon={<FontAwesomeIcon icon={faInfoCircle} />}>
+            About this tab
+          </Button>
+        </Tooltip>
+      </Stack>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Created</TableCell>
+            <TableCell>Expires</TableCell>
+            <TableCell>Browser</TableCell>
+            <TableCell>Operating System</TableCell>
+            <TableCell>IP Address</TableCell>
+            <TableCell>Action</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {currentSessions.map((session, i) => (
+            <TableRow key={`${session}-${i}`}>
+              <TableCell>{session.created}</TableCell>
+              <TableCell>{session.expires}</TableCell>
+              <TableCell>{session.browser}</TableCell>
+              <TableCell>{session.operatingSystem}</TableCell>
+              <TableCell>{session.ipAddress}</TableCell>
+              <TableCell>
+                <Button variant="contained" color="error">
+                  Log out
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <Typography variant="h2">Other Log In Sessions</Typography>
+      {otherSessions && otherSessions.length > 0 && (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Created</TableCell>
+              <TableCell>Expires</TableCell>
+              <TableCell>Browser</TableCell>
+              <TableCell>Operating System</TableCell>
+              <TableCell>IP Address</TableCell>
+              <TableCell>Action</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {otherSessions.map((session, i) => (
+              <TableRow key={`${session}-${i}`}>
+                <TableCell>{session.created}</TableCell>
+                <TableCell>{session.expires}</TableCell>
+                <TableCell>{session.browser}</TableCell>
+                <TableCell>{session.operatingSystem}</TableCell>
+                <TableCell>{session.ipAddress}</TableCell>
+                <TableCell>
+                  <Button variant="contained" color="error">
+                    Log out
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+      {(!otherSessions || otherSessions.length === 0) && (
+        <i>No additional active log in sessions.</i>
+      )}
+    </Stack>
+  );
+};

--- a/src/features/account/LogInSessions.tsx
+++ b/src/features/account/LogInSessions.tsx
@@ -36,7 +36,12 @@ export const LogInSessions: FC = () => {
   const otherSessions: any[] = [];
 
   return (
-    <Stack spacing={4}>
+    <Stack
+      spacing={4}
+      role="tabpanel"
+      id="sessions-tabpanel"
+      aria-labelledby="sessions-tab"
+    >
       <Stack direction="row" justifyContent="space-between">
         <Typography variant="h2">My Current Log In Sessions</Typography>
         <Tooltip

--- a/src/features/account/UseAgreements.tsx
+++ b/src/features/account/UseAgreements.tsx
@@ -95,7 +95,12 @@ export const UseAgreements: FC = () => {
   }, [showExpired, currentPolicies]);
 
   return (
-    <Stack spacing={4}>
+    <Stack
+      spacing={4}
+      role="tabpanel"
+      id="use-agreements-tabpanel"
+      aria-labelledby="use-agreements-tab"
+    >
       <Stack direction="row" justifyContent="space-between">
         <Typography variant="h2">My Policy Agreements</Typography>
         <Tooltip
@@ -128,6 +133,7 @@ export const UseAgreements: FC = () => {
               />
               {policies.map((policy) => (
                 <Card
+                  key={policy.name}
                   className={`${classes['policy-card']} ${
                     selectedPolicy.name === policy.name &&
                     selectedPolicy.version === policy.version

--- a/src/features/account/UseAgreements.tsx
+++ b/src/features/account/UseAgreements.tsx
@@ -70,10 +70,10 @@ const samplePolicies: Policy[] = [
  * Content for the Use Agreements tab in the Account page
  */
 export const UseAgreements: FC = () => {
-  const [policies, setPolicies] = useState(samplePolicies);
+  const currentPolicies = samplePolicies.filter((d) => d.isCurrent === true);
+  const [policies, setPolicies] = useState(currentPolicies);
   const [showExpired, setShowExpired] = useState(false);
   const [selectedPolicy, setSelectedPolicy] = useState(policies[0]);
-  const currentPolicies = samplePolicies.filter((d) => d.isCurrent === true);
 
   const handleChangeExpired = (
     event: React.ChangeEvent<HTMLInputElement>,

--- a/src/features/account/UseAgreements.tsx
+++ b/src/features/account/UseAgreements.tsx
@@ -1,0 +1,206 @@
+import {
+  faCheckCircle,
+  faTimesCircle,
+  faInfoCircle,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Chip,
+  FormControlLabel,
+  Grid,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { FC, useEffect, useState } from 'react';
+import { LabelValueTable } from '../../common/components/LabelValueTable';
+import classes from './Account.module.scss';
+
+interface Policy {
+  name: string;
+  publishedDate: string;
+  agreedDate: string;
+  version: number;
+  isCurrent: boolean;
+  content: string;
+}
+
+/**
+ * Dummy data for the log in sessions table.
+ * Can be deleted once table is linked to backend.
+ */
+const samplePolicies: Policy[] = [
+  {
+    name: 'KBase Use Agreement',
+    publishedDate: 'Jul 1, 2024	',
+    agreedDate: 'Jul 9, 2024	',
+    version: 1,
+    isCurrent: true,
+    content:
+      'Quis veniam dolor ex aliqua ullamco incididunt commodo commodo nulla. Adipisicing id dolor elit aliquip laborum aliquip ad exercitation qui dolor eu exercitation cillum. Magna voluptate ut voluptate non esse sunt esse nostrud. Labore cillum esse ex dolor aliqua do culpa eu et mollit do reprehenderit id cupidatat.',
+  },
+  {
+    name: 'KBase Data Policy',
+    publishedDate: 'Jul 1, 2024	',
+    agreedDate: 'Jul 9, 2024',
+    version: 1,
+    isCurrent: true,
+    content:
+      'Irure qui dolor ut enim culpa nulla aute nostrud deserunt commodo ad sit ut non. Ullamco velit laboris sint laboris dolore velit Lorem. Dolore sit ea sint quis Lorem laborum exercitation non voluptate. Enim sint velit anim et anim enim consequat exercitation labore aliquip mollit proident. Do pariatur elit excepteur mollit labore irure cillum tempor commodo proident proident. Et nostrud esse sunt ipsum est reprehenderit elit ex proident. Sit ipsum magna eu quis est commodo incididunt.',
+  },
+  {
+    name: 'KBase Data Policy',
+    publishedDate: 'Jul 1, 2024	',
+    agreedDate: 'Jul 9, 2024',
+    version: 0,
+    isCurrent: false,
+    content:
+      'Id amet aliqua mollit ex consectetur esse ex. Aute culpa cillum sint ullamco anim. Aliquip sunt qui enim exercitation irure in. Aliqua exercitation qui aliquip ex ut ullamco nulla ea exercitation. Consectetur duis aliqua ad dolore occaecat velit proident eiusmod fugiat.',
+  },
+];
+
+/**
+ * Content for the Use Agreements tab in the Account page
+ */
+export const UseAgreements: FC = () => {
+  const [policies, setPolicies] = useState(samplePolicies);
+  const [showExpired, setShowExpired] = useState(false);
+  const [selectedPolicy, setSelectedPolicy] = useState(policies[0]);
+  const currentPolicies = samplePolicies.filter((d) => d.isCurrent === true);
+
+  const handleChangeExpired = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    checked: boolean
+  ) => {
+    setShowExpired(checked);
+  };
+
+  const handleClickPolicy = (policy: Policy) => {
+    setSelectedPolicy(policy);
+  };
+
+  useEffect(() => {
+    if (showExpired) {
+      setPolicies(samplePolicies);
+    } else {
+      setPolicies(currentPolicies);
+    }
+  }, [showExpired, currentPolicies]);
+
+  return (
+    <Stack spacing={4}>
+      <Stack direction="row" justifyContent="space-between">
+        <Typography variant="h2">My Policy Agreements</Typography>
+        <Tooltip
+          title={
+            <Stack spacing={1}>
+              <Typography variant="body2">
+                This tab lists the Use Agreements you have agreed to during sign
+                up or log in to KBase.
+              </Typography>
+            </Stack>
+          }
+        >
+          <Button startIcon={<FontAwesomeIcon icon={faInfoCircle} />}>
+            About this tab
+          </Button>
+        </Tooltip>
+      </Stack>
+      <Box>
+        <Grid container spacing={2}>
+          <Grid item sm={3}>
+            <Stack spacing={2}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    value={showExpired}
+                    onChange={handleChangeExpired}
+                  />
+                }
+                label="Show expired policies"
+              />
+              {policies.map((policy) => (
+                <Card
+                  className={`${classes['policy-card']} ${
+                    selectedPolicy.name === policy.name &&
+                    selectedPolicy.version === policy.version
+                      ? classes['selected-card']
+                      : ''
+                  }`}
+                  onClick={() => handleClickPolicy(policy)}
+                >
+                  <CardContent>
+                    <Stack spacing={1}>
+                      <Typography variant="h5">{policy.name}</Typography>
+                      <Box>
+                        {policy.isCurrent && (
+                          <Chip
+                            icon={<FontAwesomeIcon icon={faCheckCircle} />}
+                            label="Current"
+                            color="info"
+                            size="small"
+                          />
+                        )}
+                        {!policy.isCurrent && (
+                          <Chip
+                            icon={<FontAwesomeIcon icon={faTimesCircle} />}
+                            label="Expired"
+                            color="error"
+                            size="small"
+                          />
+                        )}
+                      </Box>
+                      <div className={classes['separator']} />
+                      <LabelValueTable
+                        data={[
+                          {
+                            label: 'Version',
+                            value: policy.version,
+                          },
+                          {
+                            label: 'Published',
+                            value: policy.publishedDate,
+                          },
+                          {
+                            label: 'Agreed',
+                            value: policy.agreedDate,
+                          },
+                        ]}
+                      />
+                    </Stack>
+                  </CardContent>
+                </Card>
+              ))}
+            </Stack>
+          </Grid>
+          <Grid item sm={9}>
+            <Stack spacing={2}>
+              {selectedPolicy.isCurrent && (
+                <Alert severity="info">
+                  This policy is current. You have agreed to it and it applies
+                  to your usage of KBase.
+                </Alert>
+              )}
+              {!selectedPolicy.isCurrent && (
+                <Alert severity="error">
+                  This policy is expired. There is a newer policy that applies
+                  to your usage of KBase.
+                </Alert>
+              )}
+              <Paper className={classes['policy-content']}>
+                {selectedPolicy.content}
+              </Paper>
+            </Stack>
+          </Grid>
+        </Grid>
+      </Box>
+    </Stack>
+  );
+};

--- a/src/features/signup/AccountInformation.tsx
+++ b/src/features/signup/AccountInformation.tsx
@@ -32,8 +32,8 @@ export const AccountInformation: FC<{
         <Stack spacing={1}>
           <span>
             You have signed in with your <strong>Google</strong> account{' '}
-            <strong>ctodonnell@lbl.gov</strong>. This will be the account linked
-            to your KBase account.
+            <strong>coolkbasehuman@lbl.gov</strong>. This will be the account
+            linked to your KBase account.
           </span>
           <Accordion className={classes['collapsible-message']} disableGutters>
             <AccordionSummary

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -15,12 +15,13 @@ const RouterCompatibleLink = forwardRef<
 
 // TODO: import from single source of truth
 const baseColor = 'rgb(62, 56, 50)';
+const primaryColor = 'rgb(2, 109, 170)';
 
 export const theme = createTheme({
   palette: {
     primary: {
       // TODO: import from single source of truth
-      main: 'rgb(2, 109, 170)',
+      main: primaryColor,
     },
     warning: {
       // TODO: import from single source of truth
@@ -64,11 +65,33 @@ export const theme = createTheme({
         },
       },
     },
+    MuiInputBase: {
+      styleOverrides: {
+        root: {
+          backgroundColor: 'white',
+        },
+      },
+    },
     MuiPaper: {
       styleOverrides: {
         elevation0: {
           border: '1px solid',
           borderColor: alpha(baseColor, 0.3),
+        },
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+    MuiTabs: {
+      styleOverrides: {
+        root: {
+          borderBottom: '1px solid',
+          borderBottomColor: 'rgb(222, 213, 203)',
         },
       },
     },


### PR DESCRIPTION
Add new Account pages, components, and UI layout. Includes pages and routes for:
- Account info
- Linked Providers
- Log In Sessions
- Use Agreements

