### PR TITLE
Support Default Columns (last PR for v1.0.10)

### DIFF
--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -279,7 +279,7 @@ const TableHeader = <Datum,>({ table }: { table: TableType<Datum> }) => (
               >
                 <FAIcon
                   icon={
-                    { asc: faCaretDown, desc: faCaretUp }[
+                    { asc: faCaretUp, desc: faCaretDown }[
                       header.column.getIsSorted() as string
                     ] ?? faSort
                   }

--- a/src/features/collections/README.md
+++ b/src/features/collections/README.md
@@ -18,6 +18,7 @@ these include:
 - [// GTDB has different column names (#1)](https://github.com/kbase/ui/blob/abc33d5d357def6b3696aa2420cb500f17ea8d9f/src/features/collections/data_products/GenomeAttribs.tsx#L294)
 - [// GTDB has different column names (#2)](https://github.com/kbase/ui/blob/abc33d5d357def6b3696aa2420cb500f17ea8d9f/src/features/collections/data_products/GenomeAttribs.tsx#L298-L300)
 - [// GTDB has different column names (#3)](https://github.com/kbase/ui/blob/c3494d03bc1b6da9d43bcaf8aee66962c73b241a/src/features/collections/data_products/GenomeAttribs.tsx#L320)
+- [// GTDB has different column names (#4)](https://github.com/kbase/ui/blob/60b317e0e0653525a3d524c8e5978660349fcc79/src/features/collections/data_products/GenomeAttribs.tsx#L252)
 
 ### Other Hardcoded Column Values
 

--- a/src/features/collections/data_products/GenomeAttribs.tsx
+++ b/src/features/collections/data_products/GenomeAttribs.tsx
@@ -249,8 +249,42 @@ export const GenomeAttribs: FC<{
             : undefined,
       })),
       // HARDCODED the field order parameter and the hidden fields parameter hardcode overrides for which columns will appear and in what order
+      // GTDB has different column names (#4)
       order: ['kbase_display_name', 'kbase_id', 'genome_size'],
       exclude: ['__match__', '__sel__'],
+      defaultVisible: [
+        // GROW / ENIGMA / PMI
+        'kbase_display_name',
+        'kbase_id',
+        'completeness',
+        'contamination',
+        'classification',
+        'classification_method',
+        'kbase_gc_content',
+        'kbase_genome_size',
+        'kbase_num_protein_encoding_genes',
+        'kbase_num_cds',
+        'kbase_num_contigs',
+        // GTDB special-casing
+        'accession',
+        'gtdb_taxonomy',
+        'checkm_completeness',
+        'checkm_contamination',
+        'genome_size',
+        'gc_percentage',
+        'mimag_high_quality',
+        'mimag_medium_quality',
+        'mimag_low_quality',
+        'ncbi_assembly_level',
+        'ncbi_bioproject',
+        'ncbi_biosample',
+        'ncbi_date',
+        'ncbi_organism_name',
+        'protein_count',
+        'trna_count',
+        'gtdb_representative',
+        'gtdb_type_species_of_genus',
+      ],
     }
   );
 


### PR DESCRIPTION
adds default hidden/visible columns, frees Gavin from UI meetings

To compare this and the previous state of things, see the default hidden columns / selected in the dropdown at https://ci-europa.kbase.us/collections/GTDB/genome_attribs vs localhost (fewer visible by default)