### PR TITLE
Fix Backup cookie

### DIFF
--- a/scripts/build_deploy.ts
+++ b/scripts/build_deploy.ts
@@ -16,6 +16,7 @@ interface EnvironmentConfig {
   public_url: string;
   backup_cookie?: {
     name: string;
+    domain: string;
   };
 }
 
@@ -60,6 +61,7 @@ const setEnvironment = (
     REACT_APP_KBASE_DOMAIN: domain,
     REACT_APP_KBASE_LEGACY_DOMAIN: legacy,
     REACT_APP_KBASE_BACKUP_COOKIE_NAME: backupCookie?.name || '',
+    REACT_APP_KBASE_BACKUP_COOKIE_DOMAIN: backupCookie?.domain || '',
   };
   Object.assign(process.env, envsNew);
 };

--- a/src/features/auth/hooks.ts
+++ b/src/features/auth/hooks.ts
@@ -125,6 +125,7 @@ export const useTokenCookie = (
   useEffect(() => {
     if (
       Boolean(backupCookieName) &&
+      Boolean(backupCookieDomain) &&
       initialized &&
       currentToken &&
       backupCookieToken !== currentToken
@@ -137,6 +138,12 @@ export const useTokenCookie = (
           expires: new Date(currentExpires),
         });
       }
+    } else if (
+      (Boolean(backupCookieName) || Boolean(backupCookieDomain)) &&
+      (!backupCookieDomain || !backupCookieName)
+    ) {
+      // eslint-disable-next-line no-console
+      console.error('Backup cookie cannot be set due to bad configuration.');
     }
   }, [
     backupCookieDomain,


### PR DESCRIPTION
This PR fixes the backup cookie issue. It fixes the cookie configuration, adds tests specific to the backup cookie, and adds a missing condition that obfuscated the configuration error and accidentally worked only on login/logout or when a backup cookie was already present.