### PR TITLE
Fix initial auth/me call, skip query until token is defined

### DIFF
--- a/src/features/auth/hooks.ts
+++ b/src/features/auth/hooks.ts
@@ -14,7 +14,7 @@ import {
 export const useAuthMe = () => {
   const dispatch = useAppDispatch();
   const token = useAppSelector(authToken) || '';
-  const authAPIQuery = getMe.useQuery({ token });
+  const authAPIQuery = getMe.useQuery({ token }, { skip: !token });
   useEffect(() => {
     if (authAPIQuery && authAPIQuery.isSuccess && authAPIQuery.data) {
       const data = authAPIQuery.data;


### PR DESCRIPTION
Super minor PR to remove a call that always fails (auth/me before we have loaded the login token)