### PR TITLE
Add test utilities for mocking RTK Query hooks in unit tests

### DIFF
--- a/src/test/mockRTKQuery.ts
+++ b/src/test/mockRTKQuery.ts
@@ -1,41 +1,64 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * Utilities for mocking RTK Query hooks in tests.
  *
  * Example usage:
  * ```ts
- * // Mock a query hook with data
- * mockQuery(api.endpoints.getUsers, {
+ * // Mock a query hook that returns static data
+ * mockQuery(api.endpoints.getUsers, () => ({
  *   data: [{ id: 1, name: 'John' }]
- * });
+ * }));
  *
- * // Mock a query hook with loading state
- * mockQuery(api.endpoints.getUsers, {
+ * // Mock a query hook that uses the query parameters
+ * mockQuery(api.endpoints.getUser, (id: number) => ({
+ *   data: { id, name: 'John' }
+ * }));
+ *
+ * // Mock a query hook in loading state
+ * mockQuery(api.endpoints.getUsers, () => ({
  *   isLoading: true
- * });
+ * }));
  *
  * // Mock a query hook with error
- * mockQuery(api.endpoints.getUsers, {
+ * mockQuery(api.endpoints.getUsers, () => ({
  *   error: { message: 'Failed to fetch' }
- * });
+ * }));
  *
- * // Mock a mutation hook
- * const { trigger } = mockMutation(api.endpoints.createUser, {
- *   data: { id: 1, name: 'John' }
- * });
+ * // Mock a mutation hook with success response
+ * const { triggerFromTest } = mockMutation(
+ *   api.endpoints.createUser,
+ *   // Initial state
+ *   { isLoading: false },
+ *   // Callback when mutation is triggered
+ *   (userData: { name: string }) => ({
+ *     data: { id: 1, ...userData }
+ *   })
+ * );
  *
- * // Trigger the mocked mutation
- * await trigger({ name: 'John' });
+ * // Trigger the mocked mutation from a test
+ * const result = await triggerFromTest({ name: 'John' });
+ * // result.data = { id: 1, name: 'John' }
+ *
+ * // Mock a mutation hook with error response
+ * const { triggerFromTest, resetFromTest } = mockMutation(
+ *   api.endpoints.createUser,
+ *   { isLoading: false },
+ *   () => ({
+ *     error: { message: 'Failed to create user' }
+ *   })
+ * );
+ *
+ * // Reset the mutation state from a test
+ * resetFromTest();
+ * ```
  */
 
 import {
   ApiEndpointMutation,
   ApiEndpointQuery,
 } from '@reduxjs/toolkit/dist/query/core/module';
-// import {
-//   UseQuery,
-//   UseMutation,
-// } from '@reduxjs/toolkit/dist/query/react/buildHooks';
+import { UseQuery } from '@reduxjs/toolkit/dist/query/react/buildHooks';
 import type {
   QueryDefinition,
   MutationDefinition,
@@ -91,6 +114,9 @@ type MockQueryState<TData> = {
 type MockMutationState<TData> = {
   data?: RecursivePartial<TData>;
   error?: { message: string };
+  isLoading?: boolean;
+  isError?: boolean;
+  isSuccess?: boolean;
 };
 
 /** Function returned by useMutation */
@@ -113,76 +139,53 @@ type MutationHookResult<TData> = [
   }
 ];
 
-// /** Extracts the useQuery hook type from an RTK Query endpoint */
-// type QueryHook<E> = E extends ApiEndpointQuery<infer QueryDefinition, any>
-//   ? UseQuery<QueryDefinition>
-//   : never;
-
-// /** Extracts the useMutation hook type from an RTK Query endpoint */
-// type MutationHook<E> = E extends ApiEndpointMutation<
-//   infer MutationDefinition,
-//   any
-// >
-//   ? UseMutation<MutationDefinition>
-//   : never;
-
-// Cache to store subscribers for each endpoint
-// Allows triggering re-renders when mock data changes
-const subscriberCache = new Map<string, Set<(data: any) => void>>();
+/** Extracts the useQuery hook type from an RTK Query endpoint */
+type QueryHook<E> = Exclude<
+  E extends ApiEndpointQuery<infer QueryDefinition, any>
+    ? UseQuery<QueryDefinition>
+    : never,
+  symbol
+>;
+type QueryHookParams<E> = [
+  Exclude<Parameters<QueryHook<E>>[0], symbol>,
+  ...Omit<Parameters<QueryHook<E>>, 0>
+];
 
 /** Mocks an RTK Query endpoint for testing */
 export function mockQuery<E extends ApiEndpointQuery<any, any>>(
   endpoint: E,
-  state: MockQueryState<EndpointData<E>> = {}
+  stateCallback: (
+    ...args: QueryHookParams<E>
+  ) => MockQueryState<EndpointData<E>>
 ) {
-  const {
-    data = undefined,
-    error = undefined,
-    isLoading = false,
-    isError = !!error,
-    isSuccess = !!data,
-  } = state;
+  const getState = (...args: QueryHookParams<E>) => {
+    const {
+      data = undefined,
+      error = undefined,
+      isLoading = false,
+      isError = !!error,
+      isSuccess = !!data,
+    } = stateCallback(...args);
 
-  const mockResult: QueryHookResult<EndpointData<E>> = {
-    data,
-    error,
-    isLoading,
-    isError,
-    isSuccess,
-    isUninitialized: false,
-    isFetching: isLoading,
-    refetch: jest.fn(),
-    currentData: data as EndpointData<E>,
+    const mockResult: QueryHookResult<EndpointData<E>> = {
+      data,
+      error,
+      isLoading,
+      isError,
+      isSuccess,
+      isUninitialized: false,
+      isFetching: isLoading && !data,
+      refetch: jest.fn(),
+      currentData: data as EndpointData<E>,
+    };
+    return mockResult;
   };
 
-  if (!subscriberCache.has(endpoint.name)) {
-    subscriberCache.set(endpoint.name, new Set());
-  }
-  const subscribers = subscriberCache.get(endpoint.name);
-  if (!subscribers) throw new Error('Subscriber cache error');
-
-  const hookMock = jest.fn().mockImplementation(() => {
-    const [result, setResult] = React.useState(mockResult);
-
-    React.useEffect(() => {
-      const forceUpdate = (newData: typeof mockResult) => {
-        setResult(newData);
-      };
-
-      subscribers.add(forceUpdate);
-      return () => {
-        subscribers.delete(forceUpdate);
-      };
-    }, []);
-
-    return result;
-  });
-
-  if (subscribers.size > 0) {
-    act(() => {
-      subscribers.forEach((subscriber) => subscriber(mockResult));
+  const hookMock = jest
+    .fn()
+    .mockImplementation((...args: QueryHookParams<E>) => {
+      return getState(...args);
     });
-  }
 
   jest.spyOn(endpoint, 'useQuery' as any).mockImplementation(hookMock as any);
   return hookMock;
@@ -191,56 +194,97 @@ export function mockQuery<E extends ApiEndpointQuery<any, any>>(
 /** Mocks an RTK Mutation endpoint for testing */
 export function mockMutation<E extends ApiEndpointMutation<any, any>>(
   endpoint: E,
-  state: MockMutationState<EndpointData<E>> = {}
+  initialState: MockMutationState<EndpointData<E>>,
+  mutateCallback: (
+    ...args: Parameters<MutationTrigger<EndpointData<E>>>
+  ) => MockMutationState<EndpointData<E>>
 ) {
-  const { data = undefined, error = undefined } = state;
+  let mutateCallbackResult: MockMutationState<EndpointData<E>> | undefined =
+    undefined;
+  let hookUpdateResult:
+    | React.Dispatch<
+        React.SetStateAction<MutationHookResult<EndpointData<E>>[1]>
+      >
+    | undefined = undefined;
 
-  if (!subscriberCache.has(endpoint.name)) {
-    subscriberCache.set(endpoint.name, new Set());
-  }
-  const subscribers = subscriberCache.get(endpoint.name);
-  if (!subscribers) throw new Error('Subscriber cache error');
+  const getState = (): MutationHookResult<EndpointData<E>>[1] => {
+    const {
+      data = undefined,
+      error = undefined,
+      isLoading = false,
+      isError = !!error,
+      isSuccess = !!data,
+    } = mutateCallbackResult ?? initialState;
 
-  const trigger = jest.fn().mockResolvedValue({ data, error });
-
-  const hookResult: MutationHookResult<EndpointData<E>> = [
-    trigger as MutationTrigger<EndpointData<E>>,
-    {
+    return {
       data: data as EndpointData<E>,
       error,
-      isLoading: false,
-      isError: !!error,
-      isSuccess: !!data,
-      isUninitialized: false,
-      reset: jest.fn(),
-    },
-  ];
+      isLoading,
+      isError,
+      isSuccess,
+      isUninitialized: !data && !error && !isLoading,
+      reset: mockReset,
+    };
+  };
 
-  const hookMock = jest.fn().mockImplementation(() => {
-    const [result, setResult] = React.useState(hookResult);
-
-    React.useEffect(() => {
-      const forceUpdate = (newData: typeof hookResult) => {
-        setResult(newData);
-      };
-
-      subscribers.add(forceUpdate);
-      return () => {
-        subscribers.delete(forceUpdate);
-      };
-    }, []);
-
-    return result;
+  const mockReset = jest.fn().mockImplementation(() => {
+    mutateCallbackResult = undefined;
+    if (hookUpdateResult) hookUpdateResult(getState());
   });
 
-  if (subscribers.size > 0) {
-    act(() => {
-      subscribers.forEach((subscriber) => subscriber(hookResult));
+  const mockTrigger: MutationTrigger<EndpointData<E>> = async (...args) => {
+    if (!mutateCallback) {
+      throw new Error('No mutate callback provided');
+    }
+
+    const newState = mutateCallback(...args);
+    mutateCallbackResult = newState;
+
+    if (hookUpdateResult) {
+      if (hookUpdateResult) hookUpdateResult(getState());
+    }
+
+    return getState();
+  };
+
+  const trigger: MutationTrigger<EndpointData<E>> = jest
+    .fn()
+    .mockImplementation(mockTrigger);
+
+  const hookMock = jest.fn().mockImplementation(() => {
+    const [result, updateResult] =
+      React.useState<MutationHookResult<EndpointData<E>>[1]>(getState);
+
+    React.useEffect(() => {
+      hookUpdateResult = updateResult;
+      return () => {
+        hookUpdateResult = undefined;
+      };
+    }, [updateResult]);
+
+    return [trigger, result];
+  });
+
+  const triggerFromTest: typeof trigger = async (...args) => {
+    await act(async () => {
+      mockTrigger(...args);
     });
-  }
+    return getState();
+  };
+
+  const resetFromTest: () => void = (...args) => {
+    act(() => {
+      mockReset(...args);
+    });
+  };
 
   jest
     .spyOn(endpoint, 'useMutation' as any)
     .mockImplementation(hookMock as any);
-  return { mockFn: hookMock, trigger };
+  return {
+    hookMock,
+    triggerMock: trigger,
+    triggerFromTest,
+    resetFromTest,
+  };
 }

--- a/src/test/mockRTKQuery.ts
+++ b/src/test/mockRTKQuery.ts
@@ -1,0 +1,236 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Utilities for mocking RTK Query hooks in tests.
+ *
+ * Example usage:
+ * ```ts
+ * // Mock a query hook with data
+ * mockQuery(api.endpoints.getUsers, {
+ *   data: [{ id: 1, name: 'John' }]
+ * });
+ *
+ * // Mock a query hook with loading state
+ * mockQuery(api.endpoints.getUsers, {
+ *   isLoading: true
+ * });
+ *
+ * // Mock a query hook with error
+ * mockQuery(api.endpoints.getUsers, {
+ *   error: { message: 'Failed to fetch' }
+ * });
+ *
+ * // Mock a mutation hook
+ * const { trigger } = mockMutation(api.endpoints.createUser, {
+ *   data: { id: 1, name: 'John' }
+ * });
+ *
+ * // Trigger the mocked mutation
+ * await trigger({ name: 'John' });
+ * ```
+ */
+
+import {
+  ApiEndpointMutation,
+  ApiEndpointQuery,
+} from '@reduxjs/toolkit/dist/query/core/module';
+import type {
+  QueryDefinition,
+  MutationDefinition,
+} from '@reduxjs/toolkit/query';
+import { act } from '@testing-library/react';
+import * as React from 'react';
+
+/** Extracts return type from an RTK Query endpoint */
+type ExtractQueryData<Endpoint> = Endpoint extends ApiEndpointQuery<
+  QueryDefinition<any, any, any, infer ResultType>,
+  any
+>
+  ? ResultType
+  : never;
+
+/** Extracts return type from an RTK Mutation endpoint */
+type ExtractMutationData<Endpoint> = Endpoint extends ApiEndpointMutation<
+  MutationDefinition<any, any, any, infer ResultType>,
+  any
+>
+  ? ResultType
+  : never;
+
+/** Makes all properties of a type optional recursively */
+type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object | undefined
+    ? RecursivePartial<T[P]>
+    : T[P];
+};
+
+/** Structure of a React-Query hook result */
+type QueryHookResult<TData> = {
+  data?: RecursivePartial<TData>;
+  error?: { message: string };
+  isLoading: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  isUninitialized: boolean;
+  isFetching: boolean;
+  refetch: () => void;
+  currentData?: TData;
+};
+
+/** Configuration options for mocking a query */
+type MockQueryOptions<TData> = {
+  data?: RecursivePartial<TData>;
+  error?: { message: string };
+  isLoading?: boolean;
+  isError?: boolean;
+  isSuccess?: boolean;
+};
+
+/** Configuration options for mocking a mutation */
+type MockMutationOptions<TData> = {
+  data?: RecursivePartial<TData>;
+  error?: { message: string };
+};
+
+/** Function returned by useMutation */
+type MutationTrigger<TData> = (...args: any) => Promise<{
+  data?: TData;
+  error?: { message: string };
+}>;
+
+/** Complete return value of a useMutation hook */
+type MutationHookResult<TData> = [
+  MutationTrigger<TData>,
+  {
+    data?: TData;
+    error?: { message: string };
+    isLoading: boolean;
+    isError: boolean;
+    isSuccess: boolean;
+    isUninitialized: boolean;
+    reset: () => void;
+  }
+];
+
+// Cache to store subscribers for each endpoint
+// Allows triggering re-renders when mock data changes
+const subscriberCache = new Map<
+  ApiEndpointQuery<any, any> | ApiEndpointMutation<any, any>,
+  Set<(data: any) => void>
+>();
+
+/** Mocks an RTK Query endpoint for testing */
+export function mockQuery<E extends ApiEndpointQuery<any, any>>(
+  endpoint: E,
+  options: MockQueryOptions<ExtractQueryData<E>> = {}
+) {
+  type DataType = ExtractQueryData<E>;
+  const {
+    data = undefined,
+    error = undefined,
+    isLoading = false,
+    isError = !!error,
+    isSuccess = !!data,
+  } = options;
+
+  const mockResult: QueryHookResult<DataType> = {
+    data,
+    error,
+    isLoading,
+    isError,
+    isSuccess,
+    isUninitialized: false,
+    isFetching: isLoading,
+    refetch: jest.fn(),
+    currentData: data as DataType,
+  };
+
+  if (!subscriberCache.has(endpoint)) {
+    subscriberCache.set(endpoint, new Set());
+  }
+  const subscribers = subscriberCache.get(endpoint);
+  if (!subscribers) throw new Error('Subscriber cache error');
+
+  const mockFn = jest.fn().mockImplementation(() => {
+    const [result, setResult] = React.useState(mockResult);
+
+    React.useEffect(() => {
+      const forceUpdate = (newData: typeof mockResult) => {
+        setResult(newData);
+      };
+
+      subscribers.add(forceUpdate);
+      return () => {
+        subscribers.delete(forceUpdate);
+      };
+    }, []);
+
+    return result;
+  });
+
+  if (subscribers.size > 0) {
+    act(() => {
+      subscribers.forEach((subscriber) => subscriber(mockResult));
+    });
+  }
+
+  jest.spyOn(endpoint, 'useQuery' as any).mockImplementation(mockFn as any);
+  return mockFn;
+}
+
+/** Mocks an RTK Mutation endpoint for testing */
+export function mockMutation<E extends ApiEndpointMutation<any, any>>(
+  endpoint: E,
+  options: MockMutationOptions<ExtractMutationData<E>> = {}
+) {
+  type DataType = ExtractQueryData<E>;
+  const { data = undefined, error = undefined } = options;
+
+  if (!subscriberCache.has(endpoint)) {
+    subscriberCache.set(endpoint, new Set());
+  }
+  const subscribers = subscriberCache.get(endpoint);
+  if (!subscribers) throw new Error('Subscriber cache error');
+
+  const trigger = jest.fn().mockResolvedValue({ data, error });
+
+  const hookResult: MutationHookResult<DataType> = [
+    trigger as MutationTrigger<DataType>,
+    {
+      data: data as DataType,
+      error,
+      isLoading: false,
+      isError: !!error,
+      isSuccess: !!data,
+      isUninitialized: false,
+      reset: jest.fn(),
+    },
+  ];
+
+  const mockFn = jest.fn().mockImplementation(() => {
+    const [result, setResult] = React.useState(hookResult);
+
+    React.useEffect(() => {
+      const forceUpdate = (newData: typeof hookResult) => {
+        setResult(newData);
+      };
+
+      subscribers.add(forceUpdate);
+      return () => {
+        subscribers.delete(forceUpdate);
+      };
+    }, []);
+
+    return result;
+  });
+
+  if (subscribers.size > 0) {
+    act(() => {
+      subscribers.forEach((subscriber) => subscriber(hookResult));
+    });
+  }
+
+  jest.spyOn(endpoint, 'useMutation' as any).mockImplementation(mockFn as any);
+  return { mockFn, trigger };
+}

--- a/src/test/mockRTKQuery.ts
+++ b/src/test/mockRTKQuery.ts
@@ -239,10 +239,7 @@ export function mockMutation<E extends ApiEndpointMutation<any, any>>(
 
     const newState = mutateCallback(...args);
     mutateCallbackResult = newState;
-
-    if (hookUpdateResult) {
-      if (hookUpdateResult) hookUpdateResult(getState());
-    }
+    if (hookUpdateResult) hookUpdateResult(getState());
 
     return getState();
   };

--- a/src/test/mockRTKQueryMeta.test.tsx
+++ b/src/test/mockRTKQueryMeta.test.tsx
@@ -1,0 +1,206 @@
+import { ThemeProvider } from '@emotion/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { createTestStore } from '../app/store';
+import { getMe, loginCreate } from '../common/api/authService';
+import { parseError } from '../common/api/utils/parseError';
+import { theme } from '../theme';
+import { mockMutation, mockQuery } from './mockRTKQuery';
+
+// Test wrapper component for providing necessary context
+const TestWrapper = (
+  ui: React.ReactElement,
+  { store = createTestStore() } = {}
+) => {
+  return render(
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <BrowserRouter>
+          <main style={{ height: '100vh' }}>{ui}</main>
+        </BrowserRouter>
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+// Test component to display query results
+const TestQueryComponent = () => {
+  const result = getMe.useQuery({ token: '' });
+
+  return (
+    <div>
+      {result.isLoading && <div data-testid="loading">Loading...</div>}
+      {result.isError && (
+        <div data-testid="error">{parseError(result.error).message}</div>
+      )}
+      {result.data && (
+        <div data-testid="data">{JSON.stringify(result.data)}</div>
+      )}
+    </div>
+  );
+};
+
+// Test component to display mutation results
+const TestMutationComponent = () => {
+  const [mutate, result] = loginCreate.useMutation();
+
+  return (
+    <div>
+      <button
+        data-testid="trigger-button"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => mutate({ display: 'foobar' } as any)}
+      >
+        Trigger Mutation
+      </button>
+      {result.isError && (
+        <div data-testid="mutation-error">
+          {parseError(result.error).message}
+        </div>
+      )}
+      {result.data && (
+        <div data-testid="mutation-data">{JSON.stringify(result.data)}</div>
+      )}
+    </div>
+  );
+};
+
+describe('RTK Query Mocking Tests', () => {
+  test('mockQuery handles successful query responses', async () => {
+    const mockData = { user: 'testUser', id: 1 };
+
+    mockQuery(getMe, {
+      data: mockData,
+    });
+
+    TestWrapper(<TestQueryComponent />);
+
+    const dataElement = screen.getByTestId('data');
+    expect(dataElement).toHaveTextContent(JSON.stringify(mockData));
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+  });
+
+  test('mockQuery handles error responses', async () => {
+    const errorMessage = 'Not authorized';
+
+    mockQuery(getMe, {
+      error: { message: errorMessage },
+      isError: true,
+    });
+
+    TestWrapper(<TestQueryComponent />);
+
+    const errorElement = screen.getByTestId('error');
+    expect(errorElement).toHaveTextContent(errorMessage);
+    expect(screen.queryByTestId('data')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+  });
+
+  test('mockQuery handles loading state', () => {
+    mockQuery(getMe, {
+      isLoading: true,
+    });
+
+    TestWrapper(<TestQueryComponent />);
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('data')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+  });
+
+  test('mockMutation handles successful mutation', async () => {
+    const mockData = { token: { token: 'test-token' } };
+    mockMutation(loginCreate, {
+      data: mockData,
+    });
+
+    TestWrapper(<TestMutationComponent />);
+
+    const triggerButton = screen.getByTestId('trigger-button');
+    fireEvent.click(triggerButton);
+
+    await waitFor(() => {
+      const dataElement = screen.getByTestId('mutation-data');
+      expect(dataElement).toHaveTextContent(JSON.stringify(mockData));
+    });
+    expect(screen.queryByTestId('mutation-error')).not.toBeInTheDocument();
+  });
+
+  test('mockMutation handles error responses', async () => {
+    const errorMessage = 'Invalid credentials';
+    mockMutation(loginCreate, {
+      error: { message: errorMessage },
+    });
+
+    TestWrapper(<TestMutationComponent />);
+
+    const triggerButton = screen.getByTestId('trigger-button');
+    fireEvent.click(triggerButton);
+
+    await waitFor(() => {
+      const errorElement = screen.getByTestId('mutation-error');
+      expect(errorElement).toHaveTextContent(errorMessage);
+    });
+    expect(screen.queryByTestId('mutation-data')).not.toBeInTheDocument();
+  });
+
+  test('mockQuery updates subscribers when called multiple times', async () => {
+    const initialData = { user: 'initial', id: 1 };
+    mockQuery(getMe, { data: initialData });
+
+    TestWrapper(<TestQueryComponent />);
+
+    expect(screen.getByTestId('data')).toHaveTextContent(
+      JSON.stringify(initialData)
+    );
+
+    // Update with new data
+    const updatedData = { user: 'updated', id: 2 };
+    mockQuery(getMe, { data: updatedData });
+
+    // Should automatically update subscribers
+    await waitFor(() => {
+      expect(screen.getByTestId('data')).toHaveTextContent(
+        JSON.stringify(updatedData)
+      );
+    });
+  });
+
+  test('mockQuery refetch functionality', async () => {
+    const initialData = { user: 'initial', id: 1 };
+    const mockFn = mockQuery(getMe, { data: initialData });
+
+    TestWrapper(<TestQueryComponent />);
+
+    expect(screen.getByTestId('data')).toHaveTextContent(
+      JSON.stringify(initialData)
+    );
+
+    // Verify mock function was called
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  test('mockMutation trigger returns expected data', async () => {
+    const mockData = { token: { token: 'test-token' } };
+    const { trigger } = mockMutation(loginCreate, {
+      data: mockData,
+    });
+
+    // Test the trigger function directly
+    const response = await trigger({ user: 'test', password: 'test' });
+    expect(response.data).toEqual(mockData);
+  });
+
+  test('mockMutation trigger handles errors', async () => {
+    const errorMessage = 'Invalid credentials';
+    const { trigger } = mockMutation(loginCreate, {
+      error: { message: errorMessage },
+    });
+
+    // Test the trigger function directly
+    const response = await trigger({ user: 'test', password: 'test' });
+    expect(response.error).toEqual({ message: errorMessage });
+  });
+});


### PR DESCRIPTION
- Add mockQuery utility for query endpoints
- Add mockMutation utility for mutations
- Add tests for these mocks
- Support loading, error, and success states