### PR TITLE
Add MFA status indicators to login sessions

### DIFF
--- a/src/common/api/authService.ts
+++ b/src/common/api/authService.ts
@@ -25,6 +25,7 @@ interface TokenResponse {
   type: string;
   user: string;
   cachefor: number;
+  mfaAuthenticated: boolean | null;
 }
 
 interface AuthParams {
@@ -158,6 +159,7 @@ interface AuthResults {
       device: string;
       ip: string;
       name?: string;
+      mfaAuthenticated: boolean | null;
     }[];
     user: string;
     revokeallurl: string;

--- a/src/features/account/LogInSessions.tsx
+++ b/src/features/account/LogInSessions.tsx
@@ -19,6 +19,28 @@ import { Loader } from '../../common/components';
 import { useAppSelector } from '../../common/hooks';
 import { useLogout } from '../login/LogIn';
 
+const MfaStatusIndicator: FC<{ mfaAuthenticated: boolean | null }> = ({ mfaAuthenticated }) => {
+  if (mfaAuthenticated === true) {
+    return (
+      <Tooltip title="MFA used">
+        <FontAwesomeIcon icon={faCheck} style={{ color: 'green' }} />
+      </Tooltip>
+    );
+  } else if (mfaAuthenticated === false) {
+    return (
+      <Tooltip title="Single factor">
+        <FontAwesomeIcon icon={faCheck} style={{ color: 'red' }} />
+      </Tooltip>
+    );
+  } else {
+    return (
+      <Tooltip title="MFA not supported">
+        <FontAwesomeIcon icon={faCheck} style={{ color: 'grey' }} />
+      </Tooltip>
+    );
+  }
+};
+
 /**
  * Content for the Log In Sessions tab in the Account page
  */
@@ -68,6 +90,7 @@ export const LogInSessions: FC = () => {
                 <TableCell>Browser</TableCell>
                 <TableCell>Operating System</TableCell>
                 <TableCell>IP Address</TableCell>
+                <TableCell>MFA Status</TableCell>
                 <TableCell>Action</TableCell>
               </TableRow>
             </TableHead>
@@ -87,6 +110,9 @@ export const LogInSessions: FC = () => {
                 </TableCell>
                 <TableCell>{currentToken?.ip}</TableCell>
                 <TableCell>
+                  <MfaStatusIndicator mfaAuthenticated={currentToken?.mfaAuthenticated ?? null} />
+                </TableCell>
+                <TableCell>
                   <LogOutButton tokenId={currentToken?.id} />
                 </TableCell>
               </TableRow>
@@ -105,6 +131,7 @@ export const LogInSessions: FC = () => {
                 <TableCell>Browser</TableCell>
                 <TableCell>Operating System</TableCell>
                 <TableCell>IP Address</TableCell>
+                <TableCell>MFA Status</TableCell>
                 <TableCell>Action</TableCell>
               </TableRow>
             </TableHead>
@@ -124,6 +151,9 @@ export const LogInSessions: FC = () => {
                     {otherToken.os} {otherToken.osver}
                   </TableCell>
                   <TableCell>{otherToken.ip}</TableCell>
+                  <TableCell>
+                    <MfaStatusIndicator mfaAuthenticated={otherToken.mfaAuthenticated ?? null} />
+                  </TableCell>
                   <TableCell>
                     <LogOutButton tokenId={otherToken.id} />
                   </TableCell>

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -11,6 +11,7 @@ export interface TokenInfo {
   type: string;
   user: string;
   cachefor: number;
+  mfaAuthenticated: boolean | null;
 }
 
 interface AuthState {


### PR DESCRIPTION
Adds support for the new auth2 mfa feature https://github.com/kbase/auth2/pull/471

- Add mfaAuthenticated field to token type definitions
- Create MfaStatusIndicator component with color-coded icons
- Add MFA Status column to both Current and Other login session tables
- Display green check (MFA used), red check (single factor), or grey check (not supported)
- Include tooltips for each status type
- Only show indicators for Login token types