### PR TITLE
Fix production build TDZ crash from circular import

### DIFF
--- a/src/app/Routes.test.tsx
+++ b/src/app/Routes.test.tsx
@@ -8,12 +8,8 @@ import {
 } from 'react-router-dom';
 import { TokenInfo } from '../features/auth/authSlice';
 import { LEGACY_BASE_ROUTE } from '../features/legacy/Legacy';
-import {
-  Authed,
-  HashRouteRedirect,
-  LOGIN_ROUTE,
-  ROOT_REDIRECT_ROUTE,
-} from './Routes';
+import { Authed, HashRouteRedirect } from './Routes';
+import { LOGIN_ROUTE, ROOT_REDIRECT_ROUTE } from './routeConstants';
 import { createTestStore } from './store';
 
 describe('Routing Utils', () => {

--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -46,10 +46,11 @@ import {
   OrcidLinkError,
 } from '../features/account/OrcidLink';
 import { ManageTokens } from '../features/account/ManageTokens';
-
-export const LOGIN_ROUTE = '/login';
-export const SIGNUP_ROUTE = '/signup';
-export const ROOT_REDIRECT_ROUTE = '/narratives';
+import {
+  LOGIN_ROUTE,
+  SIGNUP_ROUTE,
+  ROOT_REDIRECT_ROUTE,
+} from './routeConstants';
 
 const Routes: FC = () => {
   useFilteredParams();

--- a/src/app/routeConstants.ts
+++ b/src/app/routeConstants.ts
@@ -1,0 +1,3 @@
+export const LOGIN_ROUTE = '/login';
+export const SIGNUP_ROUTE = '/signup';
+export const ROOT_REDIRECT_ROUTE = '/narratives';

--- a/src/features/legacy/Legacy.tsx
+++ b/src/features/legacy/Legacy.tsx
@@ -2,7 +2,7 @@ import { RefObject, useEffect, useRef, useState } from 'react';
 import { createSearchParams, useLocation, useNavigate } from 'react-router-dom';
 import { usePageTitle } from '../layout/layoutSlice';
 import { useTryAuthFromToken } from '../auth/hooks';
-import { LOGIN_ROUTE, SIGNUP_ROUTE } from '../../app/Routes';
+import { LOGIN_ROUTE, SIGNUP_ROUTE } from '../../app/routeConstants';
 import { useLogout } from '../login/LogIn';
 
 export const LEGACY_BASE_ROUTE = '/legacy';

--- a/src/features/login/LogIn.test.tsx
+++ b/src/features/login/LogIn.test.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@mui/material';
 import { fireEvent, render, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { LOGIN_ROUTE } from '../../app/Routes';
+import { LOGIN_ROUTE } from '../../app/routeConstants';
 import { createTestStore } from '../../app/store';
 import { useFilteredParams } from '../../common/hooks';
 import { theme } from '../../theme';

--- a/src/features/login/LogInContinue.tsx
+++ b/src/features/login/LogInContinue.tsx
@@ -8,7 +8,7 @@ import { useTryAuthFromToken } from '../auth/hooks';
 import { useCheckLoggedIn } from './LogIn';
 import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-import { LOGIN_ROUTE } from '../../app/Routes';
+import { LOGIN_ROUTE } from '../../app/routeConstants';
 import { useAppDispatch } from '../../common/hooks';
 import { setLoginData } from '../signup/SignupSlice';
 import { kbasePolicies } from './Policies';

--- a/src/features/signup/ProviderSelect.tsx
+++ b/src/features/signup/ProviderSelect.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import { FC } from 'react';
-import { LOGIN_ROUTE } from '../../app/Routes';
+import { LOGIN_ROUTE } from '../../app/routeConstants';
 import { ProviderButtons } from '../auth/providers';
 import { makeAuthFlowURLs } from '../auth/utils';
 import classes from './SignUp.module.scss';

--- a/src/features/signup/SignUp.tsx
+++ b/src/features/signup/SignUp.tsx
@@ -18,7 +18,7 @@ import { usePageTitle } from '../layout/layoutSlice';
 import classes from './SignUp.module.scss';
 import { KBasePolicies } from './SignupPolicies';
 import { md5 } from 'js-md5';
-import { ROOT_REDIRECT_ROUTE } from '../../app/Routes';
+import { ROOT_REDIRECT_ROUTE } from '../../app/routeConstants';
 
 const signUpSteps = [
   'Sign up with a supported provider',


### PR DESCRIPTION
## Summary
- Production build compiled successfully but crashed at runtime with `Cannot access 'EV' before initialization` (`LOGIN_ROUTE` in `Legacy.tsx`). React never mounted — `#root` stayed empty.
- Root cause: circular import between `Routes.tsx` and `Legacy.tsx`. Webpack's scope hoisting in production changed evaluation order, hitting a Temporal Dead Zone.
- Fix: extracted `LOGIN_ROUTE`, `SIGNUP_ROUTE`, and `ROOT_REDIRECT_ROUTE` into `src/app/routeConstants.ts`, breaking the cycle.

## Test plan
- [x] `npm run build` succeeds
- [x] Playwright runtime test confirms React mounts without errors (root content renders, no `pageerror` events)
- [x] Pre-commit lint/type-check hooks pass