### PR TITLE
Signup fixes: username validation, ORCID pre-fill, and CDM sidebar role gate

### DIFF
--- a/src/features/layout/LeftNavBar.tsx
+++ b/src/features/layout/LeftNavBar.tsx
@@ -72,7 +72,7 @@ const LeftNavBar: FC = () => {
           icon={faDatabase}
           badge={'alpha'}
           badgeColor={'warning'}
-          requiredRole="CDM_JUPYTERHUB_ADMIN"
+          requiredRole="BERDL_USER"
         />
       </ul>
       <ul className={classes.nav_list}>

--- a/src/features/signup/AccountInformation.test.tsx
+++ b/src/features/signup/AccountInformation.test.tsx
@@ -135,4 +135,72 @@ describe('AccountInformation', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith('/signup/3');
   });
+
+  test.each([
+    ['uppercase letters', 'BadUser'],
+    ['a leading digit', '1baduser'],
+    ['a hyphen', 'bad-user'],
+    ['a period', 'bad.user'],
+    ['repeating underscores', 'bad__user'],
+    ['a trailing underscore', 'baduser_'],
+  ])(
+    'blocks submission and shows format error for username with %s',
+    async (_label, badName) => {
+      const store = createTestStore();
+      store.dispatch(
+        setLoginData({
+          creationallowed: true,
+          expires: 0,
+          login: [],
+          provider: 'Google',
+          create: [
+            {
+              provemail: 'test@test.com',
+              provfullname: 'Test User',
+              availablename: 'testuser',
+              id: '123',
+              provusername: 'testuser',
+            },
+          ],
+        })
+      );
+      renderWithProviders(<AccountInformation />, { store });
+
+      await act(() => {
+        fireEvent.change(screen.getByRole('textbox', { name: /Full Name/i }), {
+          target: { value: 'Test User' },
+        });
+      });
+      await act(() => {
+        fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), {
+          target: { value: 'test@test.com' },
+        });
+      });
+      await act(() => {
+        fireEvent.change(
+          screen.getByRole('textbox', { name: /KBase Username/i }),
+          { target: { value: badName } }
+        );
+      });
+      await act(() => {
+        fireEvent.change(
+          screen.getByRole('textbox', { name: /Organization/i }),
+          { target: { value: 'Test Org' } }
+        );
+      });
+      await act(() => {
+        fireEvent.change(screen.getByRole('textbox', { name: /Department/i }), {
+          target: { value: 'Test Dept' },
+        });
+      });
+      await act(() => {
+        fireEvent.submit(screen.getByTestId('accountinfoform'));
+      });
+
+      expect(
+        screen.getByText(/may contain only lowercase letters/i)
+      ).toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalledWith('/signup/3');
+    }
+  );
 });

--- a/src/features/signup/AccountInformation.tsx
+++ b/src/features/signup/AccountInformation.tsx
@@ -58,8 +58,14 @@ export const AccountInformation: FC<{}> = () => {
   const [username, setUsername] = useState(account.username ?? '');
   const userAvail = loginUsernameSuggest.useQuery(username);
   const nameShort = username.length < 3;
-  const nameAvail =
-    userAvail.currentData?.availablename === username.toLowerCase();
+  const nameTooLong = username.length > 100;
+  // Mirrors backend rules in kbase/auth2 NewUserName: must start with a
+  // lowercase letter; only [a-z0-9_]; no repeating or trailing underscores.
+  const nameFormatValid =
+    /^[a-z][a-z0-9_]*$/.test(username) &&
+    !username.includes('__') &&
+    !username.endsWith('_');
+  const nameAvail = userAvail.currentData?.availablename === username;
 
   const surveyQuestion = 'How did you hear about us? (select all that apply)';
   const [optionalText, setOptionalText] = useState<Record<string, string>>({});
@@ -199,7 +205,11 @@ export const AccountInformation: FC<{}> = () => {
                   required: true,
                   onChange: (e) => setUsername(e.currentTarget.value),
                   validate: () =>
-                    !nameShort && !userAvail.isFetching && nameAvail,
+                    !nameShort &&
+                    !nameTooLong &&
+                    nameFormatValid &&
+                    !userAvail.isFetching &&
+                    nameAvail,
                 })}
                 defaultValue={account.username}
                 helperText={
@@ -207,6 +217,24 @@ export const AccountInformation: FC<{}> = () => {
                     {nameShort ? (
                       <span>
                         Username is too short.
+                        <br />
+                      </span>
+                    ) : nameTooLong ? (
+                      <span>
+                        Username must be at most 100 characters.
+                        <br />
+                      </span>
+                    ) : !nameFormatValid ? (
+                      <span>
+                        Username may contain only lowercase letters, digits, and
+                        underscores, and must start with a letter. Underscores
+                        cannot repeat or end the username.
+                        {userAvail.currentData?.availablename ? (
+                          <>
+                            {' '}
+                            Suggested: "{userAvail.currentData.availablename}".
+                          </>
+                        ) : null}
                         <br />
                       </span>
                     ) : !nameAvail && !userAvail.isFetching ? (
@@ -224,7 +252,12 @@ export const AccountInformation: FC<{}> = () => {
                     </span>
                   </>
                 }
-                error={nameShort || (!userAvail.isFetching && !nameAvail)}
+                error={
+                  nameShort ||
+                  nameTooLong ||
+                  !nameFormatValid ||
+                  (!userAvail.isFetching && !nameAvail)
+                }
               />
             </FormControl>
             <FormControl>

--- a/src/features/signup/SignupSlice.test.tsx
+++ b/src/features/signup/SignupSlice.test.tsx
@@ -1,0 +1,43 @@
+import { createTestStore } from '../../app/store';
+import { setLoginData } from './SignupSlice';
+
+const makeLoginData = (
+  provider: string,
+  availablename: string
+): Parameters<typeof setLoginData>[0] => ({
+  creationallowed: true,
+  expires: 0,
+  login: [],
+  provider,
+  create: [
+    {
+      provemail: 'jane@example.com',
+      provfullname: 'Jane Doe',
+      availablename,
+      id: '123',
+      provusername: '0000-0002-1825-0097',
+    },
+  ],
+});
+
+describe('signup setLoginData', () => {
+  test('pre-fills username from availablename for non-ORCID providers', () => {
+    const store = createTestStore();
+    store.dispatch(setLoginData(makeLoginData('Google', 'janedoe')));
+    expect(store.getState().signup.account.username).toBe('janedoe');
+  });
+
+  test('leaves username blank for ORCID logins to avoid user<N> default', () => {
+    const store = createTestStore();
+    store.dispatch(setLoginData(makeLoginData('OrcID', 'user1')));
+    expect(store.getState().signup.account.username).toBeUndefined();
+  });
+
+  test('still pre-fills display name and email for ORCID', () => {
+    const store = createTestStore();
+    store.dispatch(setLoginData(makeLoginData('OrcID', 'user1')));
+    const account = store.getState().signup.account;
+    expect(account.display).toBe('Jane Doe');
+    expect(account.email).toBe('jane@example.com');
+  });
+});

--- a/src/features/signup/SignupSlice.tsx
+++ b/src/features/signup/SignupSlice.tsx
@@ -44,9 +44,16 @@ export const signupSlice = createSlice({
       // Set provider creeation data
       state.loginData = action.payload;
       // Set account defaults from provider
-      state.account.display = action.payload?.create[0].provfullname;
-      state.account.email = action.payload?.create[0].provemail;
-      state.account.username = action.payload?.create[0].availablename;
+      const detail = action.payload?.create[0];
+      state.account.display = detail?.provfullname;
+      state.account.email = detail?.provemail;
+      // ORCID's provusername is the numeric ORCID iD, which auth2 cannot
+      // sanitize into a valid username and falls back to user<N>. Leave the
+      // field blank for ORCID so the user picks their own.
+      state.account.username =
+        action.payload?.provider === 'OrcID'
+          ? undefined
+          : detail?.availablename;
     },
     setAccount: (
       state,


### PR DESCRIPTION
## Summary

Three small fixes around signup and the authenticated sidebar.

- **Signup username validation**: Mirror the [`kbase/auth2` `NewUserName`](https://github.com/kbase/auth2/blob/main/src/main/java/us/kbase/auth2/lib/NewUserName.java) rules on the signup form: must start with a lowercase letter, only `[a-z0-9_]`, no repeating or trailing underscores, ≤100 chars. The availability check previously compared `availablename` to `username.toLowerCase()`, so inputs like `John` passed the frontend check and were then rejected by the backend. Special-character inputs (`John.Doe`, `bad-user`, …) reported "Username is not available — Suggested: X" which was actually a format problem, not a collision. Now the form shows a specific format error and submit stays blocked until the input matches the backend rules.
- **Skip `user<N>` pre-fill on ORCID signup**: ORCID's provider-supplied username is the numeric ORCID iD (e.g. `0000-0002-1825-0097`). auth2's `NewUserName.sanitizeName` strips all of that to empty and `getAvailableUserName` falls back to the literal `user<N>` (see `Authentication.java:1185-1196` and `DEFAULT_SUGGESTED_USER_NAME`). The signup form was pre-populating the username field with `user1`/`user2`/etc. for every ORCID signup. Leave the field blank when the provider is `OrcID` so the user picks their own. Display name and email pre-fill from ORCID are unchanged.
- **CDM sidebar role gate**: The CDM nav item was gated on `CDM_JUPYTERHUB_ADMIN` (admin only). Per the BERDL platform docs, `BERDL_USER` is the access role; `CDM_JUPYTERHUB_ADMIN` is a separate admin role for approving access requests. Switch the gate so users with `BERDL_USER` see the link.

## Test plan

Signup username validation
- [ ] Signup with a username containing an uppercase letter (e.g. `John`) — submit stays blocked, format error shown.
- [ ] Signup with `bad-user`, `bad__user`, `baduser_`, `1baduser` — submit stays blocked with format error.
- [ ] Signup with a valid lowercased username (e.g. `testuser`) — submit proceeds to step 3.
- [ ] Username `>` 100 chars shows the "must be at most 100 characters" error.

ORCID signup pre-fill
- [ ] Start signup via ORCID — username field is empty (not `user1`).
- [ ] Start signup via Google/Globus/another provider — username field is still pre-filled from `availablename`.
- [ ] Display name and email are still pre-filled from the ORCID identity.

CDM sidebar gate
- [ ] Log in as a user with `BERDL_USER` but no admin role — CDM link visible in sidebar.
- [ ] Log in as a user without `BERDL_USER` — CDM link not visible.

Unit tests
- [ ] `npm test -- --testPathPattern='src/features/signup/'` — all 22 tests pass (includes 6 new parameterized format-error cases and 3 new `setLoginData` cases).